### PR TITLE
Clean up and simplify BinDeps setup

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,9 +6,9 @@ using Compat
 function validate(name, handle)
     try
         fhandle = Libdl.dlsym(handle, :zmq_version)
-        major = Array(Cint,1)
-        minor = Array(Cint,1)
-        patch = Array(Cint,1)
+        major = Vector{Cint}(1)
+        minor = Vector{Cint}(1)
+        patch = Vector{Cint}(1)
         ccall(fhandle, Void, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major, minor, patch)
         return VersionNumber(major[1], minor[1], patch[1]) >= v"3"
     catch
@@ -16,23 +16,19 @@ function validate(name, handle)
     end
 end
 
-zmq = library_dependency("zmq", aliases = ["libzmq"], validate=validate)
+zmq = library_dependency("zmq", aliases = ["libzmq"], validate = validate)
 
-provides(AptGet,"libzmq3-dev",zmq)
+provides(Sources, URI("https://archive.org/download/zeromq_3.2.4/zeromq-3.2.4.tar.gz"), zmq)
+provides(BuildProcess, Autotools(libtarget = "src/.libs/libzmq." * BinDeps.shlib_ext), zmq)
 
-provides(Sources,URI("https://archive.org/download/zeromq_3.2.4/zeromq-3.2.4.tar.gz"),zmq)
-provides(BuildProcess,Autotools(libtarget = "src/.libs/libzmq."*BinDeps.shlib_ext),zmq)
+provides(AptGet, "libzmq3-dev", zmq, os = :Linux)
 
 if is_windows()
     using WinRPM
     provides(WinRPM.RPM, "zeromq", [zmq], os = :Windows)
-end
-
-if is_apple()
-    if Pkg.installed("Homebrew") === nothing
-        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")  end
+elseif is_apple()
     using Homebrew
-    provides( Homebrew.HB, "staticfloat/juliadeps/zeromq32", zmq, os = :Darwin )
+    provides(Homebrew.HB, "staticfloat/juliadeps/zeromq32", zmq, os = :Darwin)
 end
 
-@BinDeps.install @compat Dict(:zmq => :zmq)
+@BinDeps.install Dict(:zmq => :zmq)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,7 +16,7 @@ function validate(name, handle)
     end
 end
 
-zmq = library_dependency("zmq", aliases = ["libzmq"], validate = validate)
+zmq = library_dependency("zmq", aliases = ["libzmq", "libzmq.so.3"], validate = validate)
 
 provides(Sources, URI("https://archive.org/download/zeromq_3.2.4/zeromq-3.2.4.tar.gz"), zmq)
 provides(BuildProcess, Autotools(libtarget = "src/.libs/libzmq." * BinDeps.shlib_ext), zmq)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -21,7 +21,7 @@ zmq = library_dependency("zmq", aliases = ["libzmq"], validate = validate)
 provides(Sources, URI("https://archive.org/download/zeromq_3.2.4/zeromq-3.2.4.tar.gz"), zmq)
 provides(BuildProcess, Autotools(libtarget = "src/.libs/libzmq." * BinDeps.shlib_ext), zmq)
 
-provides(AptGet, "libzmq3-dev", zmq, os = :Linux)
+provides(AptGet, "libzmq3", zmq, os = :Linux)
 
 if is_windows()
     using WinRPM


### PR DESCRIPTION
Summary of changes:
* The `Array(T,n)` syntax is "deprecated" (at least per the manual, though no warning is emitted), so I've updated to `Vector{T}(n)`.
* The check for having Homebrew.jl installed is unnecessary since the REQUIRE file contains `@osx Homebrew`.
* I've reorganized the OS conditionals to use `elseif` ~~and in doing so also moved the `AptGet` provider line into an `is_linux()` block.~~
* I've removed the `@compat Dict`, as it was a relic from 0.3 support.
* Minor syntactic details such as spacing were updated so that the file has a consistent style.

(Basically just inconsequential changes that were bugging me.)