### PR TITLE
AptGet provider should install libzmq3 instead of libzmq3-dev

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ end
 
 zmq = library_dependency("zmq", aliases = ["libzmq"], validate=validate)
 
-provides(AptGet,"libzmq3-dev",zmq)
+provides(AptGet,"libzmq3",zmq)
 
 provides(Sources,URI("https://archive.org/download/zeromq_3.2.4/zeromq-3.2.4.tar.gz"),zmq)
 provides(BuildProcess,Autotools(libtarget = "src/.libs/libzmq."*BinDeps.shlib_ext),zmq)


### PR DESCRIPTION
libzmq3-dev isn't needed and conflicts with the libzmq-dev (resp. libzmq1).