### PR TITLE
Fix README Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A Julia interface to ZeroMQ
-[![Build Status](https://api.travis-ci.org/JuliaLang/ZMQ.jl.svg)](https://travis-ci.org/JuliaLang/ZMQ.jl)
+[![Build Status](https://api.travis-ci.org/JuliaInterop/ZMQ.jl.svg)](https://travis-ci.org/JuliaInterop/ZMQ.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/laybx903pd12j2ik/branch/master?svg=true)](https://ci.appveyor.com/project/tkelman/zmq-jl/branch/master)
 
 **ZMQ.jl** is a [Julia] (http://julialang.org) interface to [ZeroMQ, The Intelligent Transport Layer] (http://zeromq.org). 


### PR DESCRIPTION
They were still pointing to JuliaLang instead of JuliaInterop