### PR TITLE
make send faster by calling get_events less often

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -498,11 +498,11 @@ function send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
                 wait(socket)
             end
         else
-          notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
-          if notify_is_expensive
-            get_events(socket) != 0 && notify(socket)
-          end
-          break
+            notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+            if notify_is_expensive
+                get_events(socket) != 0 && notify(socket)
+            end
+            break
         end
     end
 end
@@ -533,11 +533,11 @@ function recv(socket::Socket)
                 wait(socket)
             end
         else
-          notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
-          if notify_is_expensive
-            get_events(socket) != 0 && notify(socket)
-          end
-          break
+            notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+            if notify_is_expensive
+                get_events(socket) != 0 && notify(socket)
+            end
+            break
         end
     end
     return zmsg

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -498,8 +498,11 @@ function send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
                 wait(socket)
             end
         else
+          notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+          if notify_is_expensive
             get_events(socket) != 0 && notify(socket)
-            break
+          end
+          break
         end
     end
 end
@@ -530,8 +533,11 @@ function recv(socket::Socket)
                 wait(socket)
             end
         else
+          notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+          if notify_is_expensive
             get_events(socket) != 0 && notify(socket)
-            break
+          end
+          break
         end
     end
     return zmsg


### PR DESCRIPTION
Fixes #142. 

I put the same change in recv, figuring it should be better there as well.