### PR TITLE
Fix method ambiguity in similar()

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -385,7 +385,7 @@ end
 isfreed(m::Message) = haskey(gc_protect, m.handle)
 
 # AbstractArray behaviors:
-similar(a::Message, T, dims::Dims) = Array{T}(dims) # ?
+similar(a::Message, ::Type{T}, dims::Dims) where {T} = Array{T}(dims) # ?
 # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
 length(zmsg::Message) = Int(ccall((:zmq_msg_size, zmq), Csize_t, (Any,), zmsg))
 size(zmsg::Message) = (length(zmsg),)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,13 @@ s2=Socket(ctx2, REQ)
 ZMQ.bind(s1, "tcp://*:5555")
 ZMQ.connect(s2, "tcp://localhost:5555")
 
-ZMQ.send(s2, Message("test request"))
+msg = Message("test request")
+# Test similar() and copy() fixes in https://github.com/JuliaInterop/ZMQ.jl/pull/165
+# Note that we have to send this message to work around
+# https://github.com/JuliaInterop/ZMQ.jl/issues/166
+@assert similar(msg, UInt8, 12) isa Vector{UInt8}
+@assert copy(msg) == convert(Vector{UInt8}, "test request")
+ZMQ.send(s2, msg)
 @assert (unsafe_string(ZMQ.recv(s1)) == "test request")
 ZMQ.send(s1, Message("test response"))
 @assert (unsafe_string(ZMQ.recv(s2)) == "test response")


### PR DESCRIPTION
Before:

```julia
julia> using ZMQ

julia> m = Message("hello")
5-element ZMQ.Message:
 0x68
 0x65
 0x6c
 0x6c
 0x6f

julia> similar(m, UInt8, 5)
ERROR: MethodError: similar(::ZMQ.Message, ::Type{UInt8}, ::Tuple{Int64}) is ambiguous. Candidates:
  similar(a::AbstractArray, ::Type{T}, dims::Tuple{Vararg{Int64,N}}) where {T, N} in Base at abstractarray.jl:527
  similar(a::AbstractArray, ::Type{T}, dims::Union{Tuple{Base.OneTo,Vararg{Base.OneTo,N} where N}, Tuple{Integer,Vararg{Integer,N} where N}}) where T in Base at abstractarray.jl:525
  similar(a::ZMQ.Message, T, dims::Tuple{Vararg{Int64,N}} where N) in ZMQ at /Users/rdeits/.julia/v0.6/ZMQ/src/ZMQ.jl:385
Possible fix, define
  similar(::ZMQ.Message, ::Type{T}, ::Tuple{Int64,Vararg{Int64,N}})
Stacktrace:
 [1] similar(::ZMQ.Message, ::Type{UInt8}, ::Int64) at ./abstractarray.jl:524
```

after:

```julia
julia> m = Message("hello")
5-element ZMQ.Message:
 0x68
 0x65
 0x6c
 0x6c
 0x6f

julia> similar(m, UInt8, 5)
5-element Array{UInt8,1}:
 0xd0
 0x46
 0x1a
 0x18
 0x01

julia> copy(m)
5-element Array{UInt8,1}:
 0x68
 0x65
 0x6c
 0x6c
 0x6f
```

Tested with Julia v0.6.2 on OSX. 