### PR TITLE
drop 0.6, use get/setproperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
     - linux
     - osx
 julia:
-    - 0.6
     - 0.7
+    - 1.0
     - nightly
 env:
   matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.68.0
+julia 0.7
 BinaryProvider 0.3.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly

--- a/deps/compile.jl
+++ b/deps/compile.jl
@@ -1,5 +1,5 @@
-using BinaryProvider, Compat
-using Compat.Libdl: dlext
+using BinaryProvider
+using Libdl: dlext
 
 function compile(libname, tarball_url, hash; prefix=BinaryProvider.global_prefix, verbose=false)
     # download to tarball_path
@@ -9,20 +9,20 @@ function compile(libname, tarball_url, hash; prefix=BinaryProvider.global_prefix
     # unpack into source_path
     tarball_dir = joinpath(prefix, "downloads", split(first(list_tarball_files(tarball_path)), '/')[1]) # e.g. "zeromq-4.2.5"
     source_path = joinpath(prefix, "downloads", "src")
-    verbose && Compat.@info("Unpacking $tarball_path into $source_path")
+    verbose && @info("Unpacking $tarball_path into $source_path")
     rm(tarball_dir, force=true, recursive=true)
     rm(source_path, force=true, recursive=true)
     unpack(tarball_path, dirname(tarball_dir); verbose=verbose)
     mv(tarball_dir, source_path)
 
     install_dir = joinpath(source_path, "julia_install")
-    verbose && Compat.@info("Compiling in $source_path...")
+    verbose && @info("Compiling in $source_path...")
     cd(source_path) do
         run(`./configure --prefix=$install_dir --without-docs --disable-libunwind --disable-perf --disable-eventfd --without-gcov --disable-curve-keygen`)
         run(`make`)
         run(`make install`)
         mkpath(libdir(prefix))
-        Compat.cp("$install_dir/lib/libzmq.$dlext", joinpath(libdir(prefix), libname*"."*dlext),
+        cp("$install_dir/lib/libzmq.$dlext", joinpath(libdir(prefix), libname*"."*dlext),
            force=true, follow_symlinks=true)
     end
 end

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -26,6 +26,7 @@ export
 
 
 include("constants.jl")
+include("optutil.jl")
 include("error.jl")
 include("socket.jl")
 include("sockopts.jl")

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -2,10 +2,11 @@
 
 module ZMQ
 
-using Libdl, Libc
-using Libc: EAGAIN
+using Base.Libc: EAGAIN
 using FileWatching: UV_READABLE, uv_pollcb, _FDWatcher
+import Sockets
 using Sockets: connect, bind, send, recv
+import Base.GC: @preserve
 
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if !isfile(depsjl_path)

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -13,15 +13,6 @@ if !isfile(depsjl_path)
 end
 include(depsjl_path)
 
-# use GC.@preserve macro if it exists, otherwise nop
-if isdefined(Base, :GC)
-    import Base.GC: @preserve
-else
-    macro preserve(args...)
-        esc(args[end])
-    end
-end
-
 export
     #Types
     StateError,Context,Socket,Message,

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -1,18 +1,11 @@
 # Support for ZeroMQ, a network and interprocess communication library
 
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module ZMQ
 
-using Compat
-using Compat.Libdl, Compat.Libc
-using Base.Libc: EAGAIN
-@static if VERSION < v"0.7.0-DEV.2359"
-    using Base.Filesystem: UV_READABLE, uv_pollcb, _FDWatcher
-else
-    using FileWatching: UV_READABLE, uv_pollcb, _FDWatcher
-end
-using Compat.Sockets: connect, bind, send, recv
+using Libdl, Libc
+using Libc: EAGAIN
+using FileWatching: UV_READABLE, uv_pollcb, _FDWatcher
+using Sockets: connect, bind, send, recv
 
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if !isfile(depsjl_path)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -4,6 +4,7 @@
 # Context options
 const IO_THREADS = 1
 const MAX_SOCKETS = 2
+const IPV6 = 42
 
 #Socket Types
 const PAIR = 0

--- a/src/context.jl
+++ b/src/context.jl
@@ -19,12 +19,12 @@ mutable struct Context
 
     function Context()
         zctx = new(_ctx_new(), WeakRef[])
-        @compat finalizer(close, zctx)
+        finalizer(close, zctx)
         return zctx
     end
-    function Context(::Compat.UndefInitializer)
+    function Context(::UndefInitializer)
         zctx = new(C_NULL, WeakRef[])
-        @compat finalizer(close, zctx)
+        finalizer(close, zctx)
         return zctx
     end
 end

--- a/src/message.jl
+++ b/src/message.jl
@@ -154,13 +154,13 @@ function Sockets.send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
                     zmsg, socket, (ZMQ_SNDMORE*SNDMORE) | ZMQ_DONTWAIT)
         if rc == -1
             zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
-            while (get_events(socket) & POLLOUT) == 0
+            while (socket.events & POLLOUT) == 0
                 wait(socket)
             end
         else
-            notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+            notify_is_expensive = !isempty(getfield(socket,:pollfd).notify.waitq)
             if notify_is_expensive
-                get_events(socket) != 0 && notify(socket)
+                socket.events != 0 && notify(socket)
             end
             break
         end
@@ -189,13 +189,13 @@ function Sockets.recv(socket::Socket)
                     zmsg, socket, ZMQ_DONTWAIT)
         if rc == -1
             zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
-            while (get_events(socket) & POLLIN) == 0
+            while (socket.events & POLLIN) == 0
                 wait(socket)
             end
         else
-            notify_is_expensive = !isempty(socket.pollfd.notify.waitq)
+            notify_is_expensive = !isempty(getfield(socket,:pollfd).notify.waitq)
             if notify_is_expensive
-                get_events(socket) != 0 && notify(socket)
+                socket.events != 0 && notify(socket)
             end
             break
         end

--- a/src/message.jl
+++ b/src/message.jl
@@ -24,7 +24,7 @@ function gc_free_fn(data::Ptr{Cvoid}, hint::Ptr{Cvoid})
 end
 
 ## Messages ##
-@compat primitive type MsgPadding 64 * 8 end
+primitive type MsgPadding 64 * 8 end
 
 mutable struct Message <: AbstractArray{UInt8,1}
     # Matching the declaration in the header: char _[64];
@@ -35,24 +35,22 @@ mutable struct Message <: AbstractArray{UInt8,1}
     function Message()
         zmsg = new()
         zmsg.handle = C_NULL
-        # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-        rc = ccall((:zmq_msg_init, libzmq), Cint, (Any,), zmsg)
+        rc = ccall((:zmq_msg_init, libzmq), Cint, (Ref{Message},), zmsg)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
         end
-        @compat finalizer(close, zmsg)
+        finalizer(close, zmsg)
         return zmsg
     end
     # Create a message with a given buffer size (for send)
     function Message(len::Integer)
         zmsg = new()
         zmsg.handle = C_NULL
-        # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-        rc = ccall((:zmq_msg_init_size, libzmq), Cint, (Any, Csize_t), zmsg, len)
+        rc = ccall((:zmq_msg_init_size, libzmq), Cint, (Ref{Message}, Csize_t), zmsg, len)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
         end
-        @compat finalizer(close, zmsg)
+        finalizer(close, zmsg)
         return zmsg
     end
 
@@ -63,13 +61,12 @@ mutable struct Message <: AbstractArray{UInt8,1}
     function Message(origin::Any, m::Ptr{T}, len::Integer) where {T}
         zmsg = new()
         zmsg.handle = gc_protect_handle(origin)
-        # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-        rc = ccall((:zmq_msg_init_data, libzmq), Cint, (Any, Ptr{T}, Csize_t, Ptr{Cvoid}, Ptr{Cvoid}),
+        rc = ccall((:zmq_msg_init_data, libzmq), Cint, (Ref{Message}, Ptr{T}, Csize_t, Ptr{Cvoid}, Ptr{Cvoid}),
                    zmsg, m, len, gc_free_fn_c[], zmsg.handle)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
         end
-        @compat finalizer(close, zmsg)
+        finalizer(close, zmsg)
         return zmsg
     end
 
@@ -94,11 +91,9 @@ isfreed(m::Message) = haskey(gc_protect, m.handle)
 
 # AbstractArray behaviors:
 Base.similar(a::Message, ::Type{T}, dims::Dims) where {T} = Array{T}(undef, dims) # ?
-# TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-Base.length(zmsg::Message) = Int(ccall((:zmq_msg_size, libzmq), Csize_t, (Any,), zmsg))
+Base.length(zmsg::Message) = Int(ccall((:zmq_msg_size, libzmq), Csize_t, (Ref{Message},), zmsg))
 Base.size(zmsg::Message) = (length(zmsg),)
-# TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-Base.unsafe_convert(::Type{Ptr{UInt8}}, zmsg::Message) = ccall((:zmq_msg_data, libzmq), Ptr{UInt8}, (Any,), zmsg)
+Base.unsafe_convert(::Type{Ptr{UInt8}}, zmsg::Message) = ccall((:zmq_msg_data, libzmq), Ptr{UInt8}, (Ref{Message},), zmsg)
 function Base.getindex(a::Message, i::Integer)
     @boundscheck if i < 1 || i > length(a)
         throw(BoundsError())
@@ -125,24 +120,21 @@ end
 # Close a message. You should not need to call this manually (let the
 # finalizer do it).
 function Base.close(zmsg::Message)
-    # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-    rc = ccall((:zmq_msg_close, libzmq), Cint, (Any,), zmsg)
+    rc = ccall((:zmq_msg_close, libzmq), Cint, (Ref{Message},), zmsg)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end
 end
 
 function Base.get(zmsg::Message, property::Integer)
-    # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-    val = ccall((:zmq_msg_get, libzmq), Cint, (Any, Cint), zmsg, property)
+    val = ccall((:zmq_msg_get, libzmq), Cint, (Ref{Message}, Cint), zmsg, property)
     if val < 0
         throw(StateError(jl_zmq_error_str()))
     end
     val
 end
 function set(zmsg::Message, property::Integer, value::Integer)
-    # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-    rc = ccall((:zmq_msg_set, libzmq), Cint, (Any, Cint, Cint), zmsg, property, value)
+    rc = ccall((:zmq_msg_set, libzmq), Cint, (Ref{Message}, Cint, Cint), zmsg, property, value)
     if rc < 0
         throw(StateError(jl_zmq_error_str()))
     end
@@ -156,10 +148,9 @@ end
 #   send(socket, zmsg)
 #   zmsg = recv(socket)
 
-function Compat.Sockets.send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
+function Sockets.send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
     while true
-        # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-        rc = ccall((:zmq_msg_send, libzmq), Cint, (Any, Ptr{Cvoid}, Cint),
+        rc = ccall((:zmq_msg_send, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint),
                     zmsg, socket, (ZMQ_SNDMORE*SNDMORE) | ZMQ_DONTWAIT)
         if rc == -1
             zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
@@ -177,25 +168,24 @@ function Compat.Sockets.send(socket::Socket, zmsg::Message, SNDMORE::Bool=false)
 end
 
 # strings are immutable, so we can send them zero-copy by default
-Compat.Sockets.send(socket::Socket, msg::AbstractString, SNDMORE::Bool=false) = send(socket, Message(msg), SNDMORE)
+Sockets.send(socket::Socket, msg::AbstractString, SNDMORE::Bool=false) = send(socket, Message(msg), SNDMORE)
 
 # Make a copy of arrays before sending, by default, since it is too
 # dangerous to require that the array not change until ZMQ is done with it.
 # For zero-copy array messages, construct a Message explicitly.
-Compat.Sockets.send(socket::Socket, msg::AbstractArray, SNDMORE::Bool=false) = send(socket, Message(copy(msg)), SNDMORE)
+Sockets.send(socket::Socket, msg::AbstractArray, SNDMORE::Bool=false) = send(socket, Message(copy(msg)), SNDMORE)
 
-function Compat.Sockets.send(f::Function, socket::Socket, SNDMORE::Bool=false)
+function Sockets.send(f::Function, socket::Socket, SNDMORE::Bool=false)
     io = IOBuffer()
     f(io)
     send(socket, Message(io), SNDMORE)
 end
 
-function Compat.Sockets.recv(socket::Socket)
+function Sockets.recv(socket::Socket)
     zmsg = Message()
     rc = -1
     while true
-        # TODO: change `Any` to `Ref{Message}` when 0.6 support is dropped.
-        rc = ccall((:zmq_msg_recv, libzmq), Cint, (Any, Ptr{Cvoid}, Cint),
+        rc = ccall((:zmq_msg_recv, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint),
                     zmsg, socket, ZMQ_DONTWAIT)
         if rc == -1
             zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))

--- a/src/optutil.jl
+++ b/src/optutil.jl
@@ -1,0 +1,14 @@
+# Utility to make it easier to define get/setproperty for a long list of options.
+
+# build up the body of get/setproperty from a list of properties, of the form
+#     if name === $prop
+#         ($doit(prop))
+#     elseif ...
+# for getproperty(value, name) or setproperty!(value, name, x)
+function propexpression(doit::Function, properties)
+    ex = :(error(typeof(value), " has no field ", name))
+    for prop in properties
+        ex = Expr(:elseif, :(name === $(QuoteNode(prop))), doit(prop), ex)
+    end
+    return Expr(:if, ex.args...)
+end

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -36,7 +36,7 @@ if Sys.isunix()
     Base.fd(socket::Socket) = RawFD(get_fd(socket))
 end
 if Sys.iswindows()
-    using Libc: WindowsRawSocket
+    using Base.Libc: WindowsRawSocket
     Base.fd(socket::Socket) = WindowsRawSocket(convert(Ptr{Cvoid}, get_fd(socket)))
 end
 

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -10,21 +10,22 @@ mutable struct Socket
             throw(StateError(jl_zmq_error_str()))
         end
         socket = new(p)
-        socket.pollfd = _FDWatcher(fd(socket), #=readable=#true, #=writable=#false)
+        setfield!(socket, :pollfd, _FDWatcher(fd(socket), #=readable=#true, #=writable=#false))
         finalizer(close, socket)
-        push!(ctx.sockets, WeakRef(socket))
+        push!(getfield(ctx, :sockets), WeakRef(socket))
         return socket
     end
     Socket(typ::Integer) = Socket(context(), typ)
 end
 
-Base.unsafe_convert(::Type{Ptr{Cvoid}}, s::Socket) = s.data
+Base.unsafe_convert(::Type{Ptr{Cvoid}}, s::Socket) = getfield(s, :data)
 
+Base.isopen(socket::Socket) = getfield(socket, :data) != C_NULL
 function Base.close(socket::Socket)
-    if socket.data != C_NULL
-        close(socket.pollfd, #=readable=#true, #=writable=#false)
+    if isopen(socket)
+        close(getfield(socket, :pollfd), #=readable=#true, #=writable=#false)
         rc = ccall((:zmq_close, libzmq), Cint,  (Ptr{Cvoid},), socket)
-        socket.data = C_NULL
+        setfield!(socket, :data, C_NULL)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
         end
@@ -33,15 +34,15 @@ end
 
 # Raw FD access
 if Sys.isunix()
-    Base.fd(socket::Socket) = RawFD(get_fd(socket))
+    Base.fd(socket::Socket) = RawFD(socket.fd)
 end
 if Sys.iswindows()
     using Base.Libc: WindowsRawSocket
-    Base.fd(socket::Socket) = WindowsRawSocket(convert(Ptr{Cvoid}, get_fd(socket)))
+    Base.fd(socket::Socket) = WindowsRawSocket(convert(Ptr{Cvoid}, socket.fd))
 end
 
-Base.wait(socket::Socket) = wait(socket.pollfd, readable=true, writable=false)
-Base.notify(socket::Socket) = @preserve socket uv_pollcb(socket.pollfd.handle, Int32(0), Int32(UV_READABLE))
+Base.wait(socket::Socket) = wait(getfield(socket, :pollfd), readable=true, writable=false)
+Base.notify(socket::Socket) = @preserve socket uv_pollcb(getfield(socket, :pollfd).handle, Int32(0), Int32(UV_READABLE))
 
 function Sockets.bind(socket::Socket, endpoint::AbstractString)
     rc = ccall((:zmq_bind, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)

--- a/src/sockopts.jl
+++ b/src/sockopts.jl
@@ -79,13 +79,11 @@ for (f,k) in ((:subscribe,6), (:unsubscribe,7))
     end
 end
 
-# Socket options of string type
+# string properties
 for (fset, fget, k) in [
-    (:_set_identity,                :_get_identity,                5)
-    (:_set_subscribe,               nothing,                      6)
-    (:_set_unsubscribe,             nothing,                      7)
-    (nothing,                      :_get_last_endpoint,          32)
-    (:_set_tcp_accept_filter,       nothing,                     38)
+    (:_set_routing_id,           :_get_routing_id,              5)
+    (nothing,                    :_get_last_endpoint,          32)
+    # (:_set_tcp_accept_filter,       nothing,                     38) #  deprecated
     ]
     if fset != nothing
         @eval function ($fset)(socket::Socket, option_val::String)
@@ -115,15 +113,15 @@ for (fset, fget, k) in [
         end
     end
 end
-@deprecate get_identity(socket::Socket) getproperty(socket, :identity)
-@deprecate set_identity(socket::Socket, val) setproperty!(socket, :identity, val)
+@deprecate get_identity(socket::Socket) getproperty(socket, :routing_id)
+@deprecate set_identity(socket::Socket, val) setproperty!(socket, :routing_id, val)
 
 # getproperty/setproperty API for socket properties
 const sockprops = (:affinity, :type, :linger, :reconnect_ivl, :backlog, :reconnect_ivl_max,
                    :rate, :recovery_ivl, :sndbuf, :rcvbuf, :rcvmore, :events, :maxmsgsize,
-                   :sndhwm, :rcvhwm, :multicast_hops, :ipv4only, :tcp_keepalive,
-                   :tcp_keepalive_idle, :tcp_keepalive_intvl, :rcvtimeo, :fd, :identity,
-                   :subscribe, :unsubscribe, :last_endpoint, :tcp_accept_filter)
+                   :sndhwm, :rcvhwm, :multicast_hops, :ipv4only,
+                   :tcp_keepalive, :tcp_keepalive_idle, :tcp_keepalive_cnt, :tcp_keepalive_intvl,
+                   :rcvtimeo, :sndtimeo, :fd, :routing_id, :last_endpoint)
 
 Base.propertynames(::Socket) = sockprops
 

--- a/src/sockopts.jl
+++ b/src/sockopts.jl
@@ -24,7 +24,7 @@ for (fset, fget, k, T) in [
     (:set_tcp_keepalive_intvl,     :get_tcp_keepalive_intvl,     37,   Cint)
     (:set_rcvtimeo,                :get_rcvtimeo,                27,   Cint)
     (:set_sndtimeo,                :get_sndtimeo,                28,   Cint)
-    (nothing,                      :get_fd,                      14, Compat.Sys.iswindows() ? Ptr{Cvoid} : Cint)
+    (nothing,                      :get_fd,                      14, Sys.iswindows() ? Ptr{Cvoid} : Cint)
     ]
     if fset != nothing
         @eval function ($fset)(socket::Socket, option_val::Integer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,9 @@ using ZMQ, Test
 	s1=Socket(REP)
 	s1.sndhwm = 1000
 	s1.linger = 1
-	s1.identity = "abcd"
+	s1.routing_id = "abcd"
 
-	@test s1.identity == "abcd"
+	@test s1.routing_id == "abcd"
 	@test s1.sndhwm === 1000
 	@test s1.linger === 1
 	@test s1.rcvmore === false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,14 +2,18 @@ using ZMQ, Test
 
 @info("Testing with ZMQ version $(ZMQ.version)")
 
-@testset "ZMQ sockets" begin
+@testset "ZMQ contexts" begin
 	ctx=Context()
 	@test ctx isa Context
+	@test (ctx.io_threads = 2) == 2
+	@test ctx.io_threads == 2
 	ZMQ.close(ctx)
 
 	#try to create socket with expired context
 	@test_throws StateError Socket(ctx, PUB)
+end
 
+@testset "ZMQ sockets" begin
 	s=Socket(PUB)
 	@test s isa Socket
 	ZMQ.close(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,18 +15,18 @@ using ZMQ, Test
 	ZMQ.close(s)
 
 	s1=Socket(REP)
-	ZMQ.set_sndhwm(s1, 1000)
-	ZMQ.set_linger(s1, 1)
-	ZMQ.set_identity(s1, "abcd")
+	s1.sndhwm = 1000
+	s1.linger = 1
+	s1.identity = "abcd"
 
-	@test ZMQ.get_identity(s1)::AbstractString == "abcd"
-	@test ZMQ.get_sndhwm(s1)::Integer == 1000
-	@test ZMQ.get_linger(s1)::Integer == 1
-	@test ZMQ.ismore(s1) == false
+	@test s1.identity == "abcd"
+	@test s1.sndhwm === 1000
+	@test s1.linger === 1
+	@test s1.rcvmore === false
 
 	s2=Socket(REQ)
-	@test ZMQ.get_type(s1) == REP
-	@test ZMQ.get_type(s2) == REQ
+	@test s1.type == REP
+	@test s2.type == REQ
 
 	ZMQ.bind(s1, "tcp://*:5555")
 	ZMQ.connect(s2, "tcp://localhost:5555")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
-using ZMQ, Compat
-using Compat.Test
+using ZMQ, Test
 
-Compat.@info("Testing with ZMQ version $(ZMQ.version)")
+@info("Testing with ZMQ version $(ZMQ.version)")
 
 @testset "ZMQ sockets" begin
 	ctx=Context()


### PR DESCRIPTION
This allows us to use get/setproperty for the properties API.

e.g. instead of `ZMQ.get_identity(socket)`, you just do `socket.routing_id` (the property was renamed in a recent ZMQ version), and tab completion of properties works.