### PR TITLE
add new low-overhead API that avoids the Message objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,22 @@ using ZMQ
 s1=Socket(REP)
 s2=Socket(REQ)
 
-ZMQ.bind(s1, "tcp://*:5555")
-ZMQ.connect(s2, "tcp://localhost:5555")
+bind(s1, "tcp://*:5555")
+connect(s2, "tcp://localhost:5555")
 
-ZMQ.send(s2, Message("test request"))
-msg = ZMQ.recv(s1)
-out=convert(IOStream, msg)
-seek(out,0)
-#read out::MemIO as usual, eg. read(out,...) or takebuf_string(out)
-#or, conveniently, use unsafe_string(msg) to retrieve a string
-
-ZMQ.send(s1, Message("test response"))
+send(s2, "test request")
+msg = recv(s1, String)
+send(s1, "test response")
 close(s1)
 close(s2)
-
 ```
+
+The `send(socket, x)` and `recv(socket, SomeType)` functions make an extra copy of the data when converting
+between ZMQ and Julia.   Alternatively, for large data sets (e.g. very large arrays or long strings), it can
+be preferable to share data, with `send(socket, Message(x))` and `msg = recv(Message)`, where the `msg::Message`
+object acts like an array of bytes; this involves some overhead so it may not be optimal for short messages.
+
+(Help in writing more detailed documentation would be welcome!)
 
 ## Troubleshooting
 

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -32,8 +32,7 @@ include("socket.jl")
 include("sockopts.jl")
 include("context.jl")
 include("message.jl")
-
-const gc_free_fn_c = Ref{Ptr{Cvoid}}()
+include("comm.jl")
 
 function __init__()
     check_deps()
@@ -45,7 +44,6 @@ function __init__()
     if version < v"3"
         error("ZMQ version $version < 3 is not supported")
     end
-    gc_free_fn_c[] = @cfunction(gc_free_fn, Cint, (Ptr{Cvoid}, Ptr{Cvoid}))
     atexit() do
         close(_context)
     end

--- a/src/_message.jl
+++ b/src/_message.jl
@@ -1,0 +1,82 @@
+## Low-level _Message type for sending/receiving small ZMQ messages directly, without the complications
+## and overhead of the Message object for sharing buffers between Julia and libzmq.
+
+# Low-level message type, matching the declaration of
+# zmq_msg_t in the header: char _[64];
+primitive type _Message 64 * 8 end
+
+const _MessageOrRef = Union{_Message,Base.RefValue{_Message}}
+
+function msg_init()
+    zmsg = Ref{_Message}()
+    rc = ccall((:zmq_msg_init, libzmq), Cint, (Ref{_Message},), zmsg)
+    rc != 0 && throw(StateError(jl_zmq_error_str()))
+    return zmsg
+end
+
+function msg_init(nbytes::Int)
+    zmsg = Ref{_Message}()
+    rc = ccall((:zmq_msg_init_size, libzmq), Cint, (Ref{_Message}, Csize_t), zmsg, nbytes % Csize_t)
+    rc != 0 && throw(StateError(jl_zmq_error_str()))
+    return zmsg
+end
+
+# note: no finalizer for _Message, so we need to call close manually!
+function Base.close(zmsg::_MessageOrRef)
+    rc = ccall((:zmq_msg_close, libzmq), Cint, (Ref{_Message},), zmsg)
+    rc != 0 && throw(StateError(jl_zmq_error_str()))
+    return nothing
+end
+
+Base.length(zmsg::_MessageOrRef) = ccall((:zmq_msg_size, libzmq), Csize_t, (Ref{_Message},), zmsg) % Int
+Base.unsafe_convert(::Type{Ptr{UInt8}}, zmsg::_MessageOrRef) =
+    ccall((:zmq_msg_data, libzmq), Ptr{UInt8}, (Ref{_Message},), zmsg)
+
+# isbits data, vectors thereof, and strings can be converted to/from _Message
+
+function _MessageRef(x::T) where {T}
+    isbitstype(T) || throw(MethodError(_MessageRef, (x,)))
+    n = sizeof(x)
+    zmsg = msg_init(n)
+    @preserve zmsg unsafe_store!(Ptr{T}(Base.unsafe_convert(Ptr{UInt8}, zmsg)), x)
+    return zmsg
+end
+
+function _MessageRef(x::Vector{T}) where {T}
+    isbitstype(T) || throw(MethodError(_MessageRef, (x,)))
+    n = sizeof(x)
+    zmsg = msg_init(n)
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{UInt8}, Ptr{T}, Csize_t), zmsg, x, n)
+    return zmsg
+end
+
+function _MessageRef(x::String)
+    n = sizeof(x)
+    zmsg = msg_init(n)
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), zmsg, x, n)
+    return zmsg
+end
+
+function unsafe_copy(::Type{Vector{T}}, zmsg::_MessageOrRef) where {T}
+    isbitstype(T) || throw(MethodError(unsafe_copy, (T, zmsg,)))
+    n = length(zmsg)
+    len, remainder = divrem(n, sizeof(T))
+    iszero(remainder) || error("message length $n not a multiple of sizeof($T)")
+    a = Array{T}(undef, len)
+    ccall(:memcpy, Ptr{Cvoid}, (Ptr{T}, Ptr{UInt8}, Csize_t), a, zmsg, n)
+    return a
+end
+
+function unsafe_copy(::Type{T}, zmsg::_MessageOrRef) where {T}
+    isbitstype(T) || throw(MethodError(unsafe_copy, (T, zmsg,)))
+    n = length(zmsg)
+    n == sizeof(T) || error("message length $n ≠ sizeof($T)")
+    return @preserve zmsg unsafe_load(Ptr{T}(Base.unsafe_convert(Ptr{UInt8}, zmsg)))
+end
+
+function unsafe_copy(::Type{String}, zmsg::_MessageOrRef)
+    n = length(zmsg)
+    return @preserve zmsg unsafe_string(Base.unsafe_convert(Ptr{UInt8}, zmsg), n)
+end
+
+unsafe_copy(::Type{IOBuffer}, zmsg::_MessageOrRef) = IOBuffer(unsafe_copy(Vector{UInt8}, zmsg))

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -1,0 +1,108 @@
+
+## Send/receive messages.
+
+############################################################################
+
+msg_send(socket::Socket, zmsg::_MessageOrRef, flags::Integer) =
+    ccall((:zmq_msg_send, libzmq), Cint, (Ref{_Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
+msg_send(socket::Socket, zmsg::Message, flags::Integer) =
+    ccall((:zmq_msg_send, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
+
+function _send(socket::Socket, zmsg, SNDMORE::Bool=false)
+    while true
+        if -1 == msg_send(socket, zmsg, (ZMQ_SNDMORE*SNDMORE) | ZMQ_DONTWAIT)
+            zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
+            while (socket.events & POLLOUT) == 0
+                wait(socket)
+            end
+        else
+            notify_is_expensive = !isempty(getfield(socket,:pollfd).notify.waitq)
+            if notify_is_expensive
+                socket.events != 0 && notify(socket)
+            end
+            break
+        end
+    end
+end
+
+# By default, we send using _Message objects, which are optimized for
+# small messages and copy the data.    If the caller wants zero-copy communications,
+# then should explicitly create a Message() object, a more heavyweight object
+# that allows zero-copy access.
+
+"""
+    send(socket::Socket, data, more=false)
+
+Send `data` over `socket`.  An optional `more=true` argument can be passed
+to indicate that `data` is a portion of a larger multipart message.
+`data` can be any `isbits` type, a `Vector` of `isbits` elements, a
+`String`, or a [`Message`](@ref) object to perform zero-copy sends
+of large arrays.
+"""
+function Sockets.send(socket::Socket, data, more::Bool=false)
+    zmsg = _MessageRef(data)
+    try
+        _send(socket, zmsg, more)
+    finally
+        close(zmsg)
+    end
+end
+
+# zero-copy version using user-allocated Message
+Sockets.send(socket::Socket, zmsg::Message, more::Bool=false) = _send(socket, zmsg, more)
+
+function Sockets.send(f::Function, socket::Socket, SNDMORE::Bool=false)
+    io = IOBuffer()
+    f(io)
+    send(socket, take!(io), SNDMORE)
+end
+
+############################################################################
+
+msg_recv(socket::Socket, zmsg::_MessageOrRef, flags::Integer) =
+    ccall((:zmq_msg_recv, libzmq), Cint, (Ref{_Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
+msg_recv(socket::Socket, zmsg::Message, flags::Integer) =
+    ccall((:zmq_msg_recv, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
+
+function _recv!(socket::Socket, zmsg)
+    while true
+        if -1 == msg_recv(socket, zmsg, ZMQ_DONTWAIT)
+            zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
+            while socket.events & POLLIN== 0
+                wait(socket)
+            end
+        else
+            notify_is_expensive = !isempty(getfield(socket,:pollfd).notify.waitq)
+            if notify_is_expensive
+                socket.events != 0 && notify(socket)
+            end
+            break
+        end
+    end
+    return zmsg
+end
+
+"""
+   recv(socket::Socket) :: Message
+
+Return a `Message` object representing a message received from a ZMQ `Socket`
+(without making a copy of the message data).
+"""
+Sockets.recv(socket::Socket) = _recv!(socket, Message())
+
+"""
+   recv(socket::Socket, ::Type{T})
+
+Receive a message of type `T` (typically a `String`, `Vector{UInt8}`, or [`isbits`](@ref) type)
+from a ZMQ `Socket`.   (Makes a copy of the message data; you can alternatively use
+`recv(socket)` to work with zero-copy bytearray-like representation for large messages.)
+"""
+function Sockets.recv(socket::Socket, ::Type{T}) where {T}
+    zmsg = msg_init()
+    try
+        _recv!(socket, zmsg)
+        return unsafe_copy(T, zmsg)
+    finally
+        close(zmsg)
+    end
+end


### PR DESCRIPTION
Now you can just do `send(socket, x)` to send `x` (a bitstype, String, or array of bitstype) and `recv(socket, T)` to receive an object of type `T`, without the overhead of allocating a `Message` object.  This simplified API copies the data to/from ZMQ, and should be lower overhead for small messages.

`Message` objects are still supported, and can be used to send/receive large messages without copying the data.