### PR TITLE
Remove Sockets dependency/namespace insertion

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -5,8 +5,6 @@ module ZMQ
 import Libdl
 using Base.Libc: EAGAIN
 using FileWatching: UV_READABLE, uv_pollcb, _FDWatcher
-import Sockets
-using Sockets: connect, bind, send, recv
 import Base.GC: @preserve
 
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
@@ -19,11 +17,9 @@ export
     #Types
     StateError,Context,Socket,Message,
     #functions
-    set, subscribe, unsubscribe,
+    set, subscribe, unsubscribe, connect, bind, send, recv
     #Constants
     IO_THREADS,MAX_SOCKETS,PAIR,PUB,SUB,REQ,REP,ROUTER,DEALER,PULL,PUSH,XPUB,XSUB,XREQ,XREP,UPSTREAM,DOWNSTREAM,MORE,POLLIN,POLLOUT,POLLERR,STREAMER,FORWARDER,QUEUE,SNDMORE,
-    #Sockets
-    connect, bind, send, recv
 
 
 include("constants.jl")

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -5,6 +5,7 @@ module ZMQ
 import Libdl
 using Base.Libc: EAGAIN
 using FileWatching: UV_READABLE, uv_pollcb, _FDWatcher
+import Sockets
 import Base.GC: @preserve
 
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
@@ -17,9 +18,9 @@ export
     #Types
     StateError,Context,Socket,Message,
     #functions
-    set, subscribe, unsubscribe, connect, bind, send, recv
+    set, subscribe, unsubscribe, connect, bind, send, recv,
     #Constants
-    IO_THREADS,MAX_SOCKETS,PAIR,PUB,SUB,REQ,REP,ROUTER,DEALER,PULL,PUSH,XPUB,XSUB,XREQ,XREP,UPSTREAM,DOWNSTREAM,MORE,POLLIN,POLLOUT,POLLERR,STREAMER,FORWARDER,QUEUE,SNDMORE,
+    IO_THREADS,MAX_SOCKETS,PAIR,PUB,SUB,REQ,REP,ROUTER,DEALER,PULL,PUSH,XPUB,XSUB,XREQ,XREP,UPSTREAM,DOWNSTREAM,MORE,POLLIN,POLLOUT,POLLERR,STREAMER,FORWARDER,QUEUE,SNDMORE
 
 
 include("constants.jl")

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -48,8 +48,16 @@ function send(socket::Socket, data; more::Bool=false)
     end
 end
 
+function Sockets.send(socket::Socket, data; more::Bool=false)
+  depwarn("Sockets.send(socket::Socket, data; more::Bool) is deprecated, use send(socket::Socket, data; more::Bool=false) instead.", nothing)
+  send(socket, data, more=more)
+end
+
 # zero-copy version using user-allocated Message
 send(socket::Socket, zmsg::Message; more::Bool=false) = _send(socket, zmsg, more)
+function Sockets.send(socket::Socket, zmsg::Message; more::Bool=false) 
+  depwarn("Sockets.send(socket::Socket, zmsg::Message; more::Bool=false) is deprecated, use send(socket::Socket, zmsg::Message; more::Bool=false) instead.", nothing)
+end
 
 @deprecate send(socket::Socket, data, more::Bool) send(socket, data; more=more)
 
@@ -91,6 +99,10 @@ Return a `Message` object representing a message received from a ZMQ `Socket`
 (without making a copy of the message data).
 """
 recv(socket::Socket) = _recv!(socket, Message())
+function Sockets.recv(socket::Socket) 
+    depwarn("Sockets.recv(socket::Socket) is deprecated, use recv(socket::Socket) instead.", nothing)
+    recv(socket::Socket)
+end
 
 """
    recv(socket::Socket, ::Type{T})
@@ -107,4 +119,10 @@ function recv(socket::Socket, ::Type{T}) where {T}
     finally
         close(zmsg)
     end
+end
+
+function Sockets.recv(socket::Socket, t::Type{T}) where {T}
+    depwarn("Sockets.recv(socket::Socket, ::Type{T}) where {T} is deprecated, use recv(socket::Socket, ::Type{T}) where {T}
+ instead.", nothing)
+    recv(socket, t)
 end

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -39,7 +39,7 @@ to indicate that `data` is a portion of a larger multipart message.
 `String`, or a [`Message`](@ref) object to perform zero-copy sends
 of large arrays.
 """
-function Sockets.send(socket::Socket, data; more::Bool=false)
+function send(socket::Socket, data; more::Bool=false)
     zmsg = _MessageRef(data)
     try
         _send(socket, zmsg, more)
@@ -49,12 +49,11 @@ function Sockets.send(socket::Socket, data; more::Bool=false)
 end
 
 # zero-copy version using user-allocated Message
-Sockets.send(socket::Socket, zmsg::Message; more::Bool=false) = _send(socket, zmsg, more)
+send(socket::Socket, zmsg::Message; more::Bool=false) = _send(socket, zmsg, more)
 
-import Sockets: send
 @deprecate send(socket::Socket, data, more::Bool) send(socket, data; more=more)
 
-function Sockets.send(f::Function, socket::Socket; more::Bool=false)
+function send(f::Function, socket::Socket; more::Bool=false)
     io = IOBuffer()
     f(io)
     send(socket, take!(io); more=more)
@@ -91,7 +90,7 @@ end
 Return a `Message` object representing a message received from a ZMQ `Socket`
 (without making a copy of the message data).
 """
-Sockets.recv(socket::Socket) = _recv!(socket, Message())
+recv(socket::Socket) = _recv!(socket, Message())
 
 """
    recv(socket::Socket, ::Type{T})
@@ -100,7 +99,7 @@ Receive a message of type `T` (typically a `String`, `Vector{UInt8}`, or [`isbit
 from a ZMQ `Socket`.   (Makes a copy of the message data; you can alternatively use
 `recv(socket)` to work with zero-copy bytearray-like representation for large messages.)
 """
-function Sockets.recv(socket::Socket, ::Type{T}) where {T}
+function recv(socket::Socket, ::Type{T}) where {T}
     zmsg = msg_init()
     try
         _recv!(socket, zmsg)

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -44,14 +44,14 @@ end
 Base.wait(socket::Socket) = wait(getfield(socket, :pollfd), readable=true, writable=false)
 Base.notify(socket::Socket) = @preserve socket uv_pollcb(getfield(socket, :pollfd).handle, Int32(0), Int32(UV_READABLE))
 
-function Sockets.bind(socket::Socket, endpoint::AbstractString)
+function bind(socket::Socket, endpoint::AbstractString)
     rc = ccall((:zmq_bind, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end
 end
 
-function Sockets.connect(socket::Socket, endpoint::AbstractString)
+function connect(socket::Socket, endpoint::AbstractString)
     rc=ccall((:zmq_connect, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -50,10 +50,19 @@ function bind(socket::Socket, endpoint::AbstractString)
         throw(StateError(jl_zmq_error_str()))
     end
 end
+function Sockets.bind(socket::Socket, endpoint::AbstractString)
+    depwarn("Sockets.bind(socket::Socket, endpoint::AbstractString) is deprecated, use bind(socket::Socket, endpoint::AbstractString) insead.", nothing)
+    bind(socket, endpoint)
+end
 
 function connect(socket::Socket, endpoint::AbstractString)
     rc=ccall((:zmq_connect, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end
+end
+
+function Sockets.connect(socket::Socket, endpoint::AbstractString)
+    depwarn("Sockets.connect(socket::Socket, endpoint::AbstractString) is deprecated, use connect(socket::Socket, endpoint::AbstractString) insead.", nothing)
+    connect(socket, endpoint)
 end


### PR DESCRIPTION
I think ZMQ is sufficiently different enough from Sockets that we should keep ZMQ functions in a separate namespace. Thoughts?