### PR TITLE
Fix `Base.propertynames()` bug

### DIFF
--- a/src/message.jl
+++ b/src/message.jl
@@ -142,7 +142,7 @@ function _set(zmsg::Message, property::Integer, value::Integer)
         throw(StateError(jl_zmq_error_str()))
     end
 end
-Base.propertynames(zmsg::Message) = (:more)
+Base.propertynames(zmsg::Message) = (:more,)
 function Base.getproperty(zmsg::Message, name::Symbol)
     if name === :more
         return _get(zmsg, MORE)


### PR DESCRIPTION
This method should return a tuple.

Fixes https://github.com/JuliaLang/julia/issues/36135