### PR TITLE
Add support for draft socket types

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -28,6 +28,7 @@ include("socket.jl")
 include("sockopts.jl")
 include("message.jl")
 include("comm.jl")
+include("draft.jl")
 
 function __init__()
     major = Ref{Cint}()

--- a/src/draft.jl
+++ b/src/draft.jl
@@ -1,0 +1,18 @@
+# Draft ZMQ capabilities
+# Note that usage of these APIs is not guaranteed to be compatible across ZMQ versions.
+# Use at your own risk.
+module Draft
+
+export SERVER, CLIENT, RADIO, DISH, GATHER, SCATTER, DGRAM
+
+# Draft Socket Types, as of ZMQ 4.3.2
+const SERVER = 12
+const CLIENT = 13
+const RADIO = 14
+const DISH = 15
+const GATHER = 16
+const SCATTER = 17
+const DGRAM = 18
+
+end # module Draft
+


### PR DESCRIPTION
These APIs are not yet fully stable, so using them across ZMQ versions
is not guaranteed to work.  Within a ZMQ version, they should be more or
less functional however, so let's expose them but within a `Draft`
module that signals to the user a whiff of caveat emptor.

Associated Yggdrasil PR enabling the draft code within libzmq:
https://github.com/JuliaPackaging/Yggdrasil/pull/1128