### PR TITLE
Add `immediate` property to sockets

### DIFF
--- a/src/sockopts.jl
+++ b/src/sockopts.jl
@@ -24,6 +24,7 @@ for (fset, fget, k, T) in [
     (:set_tcp_keepalive_intvl,     :get_tcp_keepalive_intvl,     37,   Cint)
     (:set_rcvtimeo,                :get_rcvtimeo,                27,   Cint)
     (:set_sndtimeo,                :get_sndtimeo,                28,   Cint)
+    (:set_immediate,               :get_immediate,               39,   Cint)
     (nothing,                      :get_fd,                      14, Sys.iswindows() ? Ptr{Cvoid} : Cint)
     ]
     if fset != nothing
@@ -121,7 +122,7 @@ const sockprops = (:affinity, :type, :linger, :reconnect_ivl, :backlog, :reconne
                    :rate, :recovery_ivl, :sndbuf, :rcvbuf, :rcvmore, :events, :maxmsgsize,
                    :sndhwm, :rcvhwm, :multicast_hops, :ipv4only,
                    :tcp_keepalive, :tcp_keepalive_idle, :tcp_keepalive_cnt, :tcp_keepalive_intvl,
-                   :rcvtimeo, :sndtimeo, :fd, :routing_id, :last_endpoint)
+                   :rcvtimeo, :sndtimeo, :fd, :routing_id, :last_endpoint, :immediate)
 
 Base.propertynames(::Socket) = sockprops
 @eval function Base.getproperty(value::Socket, name::Symbol)


### PR DESCRIPTION
This allows the setting of the sockopt `ZMQ_IMMEDIATE`, which allows for
more reliable message passing when dealing with round-robin style
sockets such as a `DEALER` socket.  See the man page for setsockopt for
more information: http://api.zeromq.org/master:zmq-setsockopt