### PR TITLE
Seek to beginning of IOBuffer before returning it

### DIFF
--- a/src/message.jl
+++ b/src/message.jl
@@ -116,6 +116,7 @@ Base.unsafe_string(zmsg::Message) = @preserve zmsg unsafe_string(pointer(zmsg), 
 function Base.convert(::Type{IOStream}, zmsg::Message)
     s = IOBuffer()
     write(s, zmsg)
+    seek(s, 0)
     return s
 end
 


### PR DESCRIPTION
It’s impossible to read from an IOBuffer that was just written to: its
position is set to its end and reading from it results in EOFError.