### PR TITLE
[compat] entry for ZeroMQ_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 ZeroMQ_jll = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
 
 [compat]
+ZeroMQ_jll = "4"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Or was it intentional to leave it out?

Feel free to edit `"4"` into whatever is appropriate