### PR TITLE
Add overloads for Base.elsize and Base.strides to Message

### DIFF
--- a/src/message.jl
+++ b/src/message.jl
@@ -111,6 +111,9 @@ end
 # Convert message to string (copies data)
 Base.unsafe_string(zmsg::Message) = @preserve zmsg unsafe_string(pointer(zmsg), length(zmsg))
 
+Base.elsize(::Message) = 1
+Base.strides(::Message) = (1,)
+
 # Build an IOStream from a message
 # Copies the data
 function Base.convert(::Type{IOStream}, zmsg::Message)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,11 @@ end
 	ZMQ.connect(s2, "tcp://localhost:5555")
 
 	msg = Message("test request")
+
+    # Smoke tests
+    @test Base.elsize(msg) == 1
+    @test Base.strides(msg) == (1,)
+
 	# Test similar() and copy() fixes in https://github.com/JuliaInterop/ZMQ.jl/pull/165
 	# Note that we have to send this message to work around
 	# https://github.com/JuliaInterop/ZMQ.jl/issues/166


### PR DESCRIPTION
This is handy if deserializing a Message with MsgPack, which requires these
methods to be defined.