### PR TITLE
Update docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-
-[compat]
-Documenter = "~0.20"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,7 @@ makedocs(
         ],
         "Reference" => "reference.md",
     ],
-    #= Documenter.HTML(), =#
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true")
 )
 
 deploydocs(

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,4 +1,51 @@
 # Reference
 
-```@index
+## Sockets
+
+The ZMQ Socket type:
+
+```@docs
+Socket
+isopen
+close
+```
+
+[`Socket`](@ref) implements the
+[`Sockets`](https://docs.julialang.org/en/v1/stdlib/Sockets/) interface:
+```@docs
+bind
+connect
+recv
+send
+```
+
+ZMQ socket types (note: some of these are aliases; e.g. `XREQ = DEALER`):
+```@docs
+PAIR
+PUB
+SUB
+REQ
+REP
+DEALER
+ROUTER
+PULL
+PUSH
+XPUB
+XSUB
+XREQ
+XREP
+UPSTREAM
+DOWNSTREAM
+```
+
+## Messages
+
+```@docs
+Message
+```
+
+## Context
+
+```@docs
+ZMQ.context
 ```

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -48,7 +48,12 @@ function Sockets.send(socket::Socket, data; more::Bool=false)
     end
 end
 
-# zero-copy version using user-allocated Message
+"""
+    send(socket::Socket, zmsg::Message; more::Bool=false)
+
+Zero-copy version of [`Sockets.send(socket, data)`](@ref) using a user-allocated
+[`Message`](@ref).
+"""
 Sockets.send(socket::Socket, zmsg::Message; more::Bool=false) = _send(socket, zmsg, more)
 
 import Sockets: send
@@ -86,7 +91,7 @@ function _recv!(socket::Socket, zmsg)
 end
 
 """
-   recv(socket::Socket) :: Message
+    recv(socket::Socket)
 
 Return a `Message` object representing a message received from a ZMQ `Socket`
 (without making a copy of the message data).
@@ -94,11 +99,14 @@ Return a `Message` object representing a message received from a ZMQ `Socket`
 Sockets.recv(socket::Socket) = _recv!(socket, Message())
 
 """
-   recv(socket::Socket, ::Type{T})
+    recv(socket::Socket, ::Type{T})
 
-Receive a message of type `T` (typically a `String`, `Vector{UInt8}`, or [`isbits`](@ref) type)
-from a ZMQ `Socket`.   (Makes a copy of the message data; you can alternatively use
-`recv(socket)` to work with zero-copy bytearray-like representation for large messages.)
+Receive a message of type `T` (typically a `String`, `Vector{UInt8}`, or
+[`isbits`](https://docs.julialang.org/en/v1/base/base/#Base.isbits) type)
+from a ZMQ [`Socket`](@ref).  (Makes a copy of the message data; you can alternatively
+use [`recv(socket)`](@ref) to work with zero-copy bytearray-like representation for
+large messages.)
+
 """
 function Sockets.recv(socket::Socket, ::Type{T}) where {T}
     zmsg = msg_init()

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -6,21 +6,35 @@ const IO_THREADS = 1
 const MAX_SOCKETS = 2
 const IPV6 = 42
 
-#Socket Types
+"[PAIR](https://zeromq.org/socket-api/#pair-socket) socket."
 const PAIR = 0
+"[PUB](https://zeromq.org/socket-api/#pub-socket) socket."
 const PUB = 1
+"[SUB](https://zeromq.org/socket-api/#sub-socket) socket."
 const SUB = 2
+"[REQ](https://zeromq.org/socket-api/#req-socket) socket."
 const REQ = 3
+"[REP](https://zeromq.org/socket-api/#rep-socket) socket."
 const REP = 4
+"[DEALER](https://zeromq.org/socket-api/#dealer-socket) socket."
 const DEALER = 5
+"[ROUTER](https://zeromq.org/socket-api/#router-socket) socket."
 const ROUTER = 6
+"[PULL](https://zeromq.org/socket-api/#pull-socket) socket."
 const PULL = 7
+"[PUSH](https://zeromq.org/socket-api/#push-socket) socket."
 const PUSH = 8
+"[XPUB](https://zeromq.org/socket-api/#xpub-socket) socket."
 const XPUB = 9
+"[XSUB](https://zeromq.org/socket-api/#xsub-socket) socket."
 const XSUB = 10
+"[XREQ](https://zeromq.org/socket-api/#dealer-socket) socket."
 const XREQ = DEALER
+"[XREP](https://zeromq.org/socket-api/#router-socket) socket."
 const XREP = ROUTER
+"[UPSTREAM](https://zeromq.org/socket-api/#pull-socket) socket."
 const UPSTREAM = PULL
+"[DOWNSTREAM](https://zeromq.org/socket-api/#push-socket) socket."
 const DOWNSTREAM = PUSH
 
 #Message options

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -1,8 +1,31 @@
-## Sockets ##
+"""
+A ZMQ socket.
+
+    Socket(typ::Integer)
+
+Create a socket of a certain type.
+
+---
+
+    Socket(ctx::Context, typ::Integer)
+
+Create a socket in a given context.
+
+---
+
+    Socket(f::Function, args...)
+
+Do-block constructor.
+"""
 mutable struct Socket
     data::Ptr{Cvoid}
     pollfd::_FDWatcher
 
+    """
+        Socket(ctx::Context, typ::Integer)
+
+    Create a socket in a given context.
+    """
     function Socket(ctx::Context, typ::Integer)
         p = ccall((:zmq_socket, libzmq), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), ctx, typ)
         if p == C_NULL
@@ -14,9 +37,20 @@ mutable struct Socket
         push!(getfield(ctx, :sockets), WeakRef(socket))
         return socket
     end
+
+    """
+        Socket(typ::Integer)
+
+    Create a socket of a certain type.
+    """
     Socket(typ::Integer) = Socket(context(), typ)
 end
 
+"""
+    Socket(f::Function, args...)
+
+Do-block constructor.
+"""
 function Socket(f::Function, args...)
     socket = Socket(args...)
     try
@@ -28,7 +62,14 @@ end
 
 Base.unsafe_convert(::Type{Ptr{Cvoid}}, s::Socket) = getfield(s, :data)
 
+"""
+    Base.isopen(socket::Socket)
+"""
 Base.isopen(socket::Socket) = getfield(socket, :data) != C_NULL
+
+"""
+    Base.close(socket::Socket)
+"""
 function Base.close(socket::Socket)
     if isopen(socket)
         close(getfield(socket, :pollfd), #=readable=#true, #=writable=#false)
@@ -52,6 +93,13 @@ end
 Base.wait(socket::Socket) = wait(getfield(socket, :pollfd), readable=true, writable=false)
 Base.notify(socket::Socket) = @preserve socket uv_pollcb(getfield(socket, :pollfd).handle, Int32(0), Int32(UV_READABLE))
 
+"""
+    Sockets.bind(socket::Socket, endpoint::AbstractString)
+
+Bind the socket to an endpoint. Note that the endpoint must be formatted as
+described
+[here](http://api.zeromq.org/4-3:zmq-bind). e.g. `tcp://127.0.0.1:42000`.
+"""
 function Sockets.bind(socket::Socket, endpoint::AbstractString)
     rc = ccall((:zmq_bind, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
     if rc != 0
@@ -59,6 +107,11 @@ function Sockets.bind(socket::Socket, endpoint::AbstractString)
     end
 end
 
+"""
+    Sockets.connect(socket::Socket, endpoint::AbstractString)
+
+Connect the socket to an endpoint.
+"""
 function Sockets.connect(socket::Socket, endpoint::AbstractString)
     rc=ccall((:zmq_connect, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
     if rc != 0


### PR DESCRIPTION
- Update Documenter.jl
- Add/fix docstrings for a bunch of functions/types
- Expand reference page

Things that might need to be changed:
- AFAICT the docs are generated with Travis CI, but I don't think that's running anymore. Travis CI stopped free builds for public projects [a while ago](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing). Maybe the docs could be generated by appveyor? Or Github actions?
- Documenter.jl has a problem with recognizing inner constructors of structs, when I tried adding e.g. `Socket(typ::Integer)` I got:
  ```julia
  ┌ Warning: no docs found for 'Socket(typ::Integer)' in `@docs` block in src/reference.md:7-12
  │ ```@docs
  │ Socket
  │ Socket(typ::Integer)
  │ isopen
  │ close
  │ ```
  └ @ Documenter.Expanders ~/.julia/packages/Documenter/vylnb/src/Utilities/Utilities.jl:34
  ```
  Possibly related: https://github.com/JuliaDocs/Documenter.jl/issues/396
  I got around this by copying the constructor docstrings into the type docstrings and manually separating them with horizontal lines to approximate what Documenter.jl does with method overloads:
  ![image](https://user-images.githubusercontent.com/5361518/170835975-caf7d67a-96f9-465f-aabb-b48713e91e6a.png)

  I left the docstrings on the constructors too for the sake of clarity (though now they're duplicated so perhaps it would be better to just keep them in the type docstring).

Should fix #203.