### PR TITLE
Add Aqua.jl to the tests and add compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,17 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 ZeroMQ_jll = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
 
 [compat]
+Aqua = "0.8.7"
+FileWatching = "<0.0.1, 1"
 PrecompileTools = "1"
+Sockets = "<0.0.1, 1"
+Test = "<0.0.1, 1"
 ZeroMQ_jll = "4"
 julia = "1.3"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+import Aqua
 using ZMQ, Test
 
 @info("Testing with ZMQ version $(ZMQ.version)")
@@ -146,4 +147,8 @@ end
 	@test isopen(ctx)
     end
     @test !isopen(leaked_ctx)
+end
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(ZMQ)
 end


### PR DESCRIPTION
The compat bounds are the only issues found by Aqua.jl. Added the compat bounds following the guidelines from this post:
https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958