### PR TITLE
Generate complete bindings to libzmq

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(
             "man/examples.md",
         ],
         "Reference" => "reference.md",
+        "Bindings" => "bindings.md",
         "Changelog" => "changelog.md"
     ],
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true")

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -12,6 +12,7 @@ Changelog](https://keepachangelog.com).
 ### Added
 - Support for creating [`Message`](@ref)'s from the new `Memory` type in Julia
   1.11 ([#244]).
+- Full [Bindings](@ref) to libzmq ([#232]).
 
 ### Fixed
 - Fixed [`isfreed()`](@ref), which would previously return the wrong values

--- a/docs/src/bindings.md
+++ b/docs/src/bindings.md
@@ -1,0 +1,15 @@
+# Bindings
+
+This page documents the low-level bindings to libzmq that were automatically
+generated. Where possible, the docstrings link to the [upstream
+documentation](https://libzmq.readthedocs.io). Bindings have not been generated
+for deprecated functions.
+
+!!! danger
+    These bindings are unsafe, do not use them unless you know what you're doing.
+
+---
+
+```@autodocs
+Modules = [ZMQ.lib]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,6 @@
 
 The [Guide](@ref) provides a tutorial explaining how to get started using ZMQ.jl.
 
-Some examples of packages using Documenter can be found on the [Examples](@ref) page.
+Some examples are linked on the [Examples](@ref) page.
 
-See the [Reference](@ref) for the complete list of documented functions and types.
+See the [Reference](@ref) for the complete list of wrapped functions and types.

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+ZeroMQ_jll = "8f1865be-045e-5c20-9c9f-bfbfb0764568"

--- a/gen/gen.jl
+++ b/gen/gen.jl
@@ -1,0 +1,77 @@
+import Clang
+import ZeroMQ_jll
+import MacroTools: @capture, postwalk, prettify
+
+
+# Helper function to look through all the generated bindings and create new
+# zmq_msg_* methods for the Message type. We need to create these overloads
+# because the Message type relies on _Message (i.e. lib.zmq_msg_t) under the
+# hood, and _Message is an immutable type so it doesn't have a stable address,
+# and so cannot safely be passed to a ccall.
+#
+# We get around this for _Message by always using a Ref{_Message}, but Message
+# is a mutable struct with a _Message as its first field. It's safe to pass a
+# pointer to a Message to libzmq because the address of the Message is the same
+# as its first field, the _Message. But to do that we need to create methods to
+# ccall libzmq with the Message type instead of lib.zmq_msg_t (_Message).
+function get_msg_methods(ctx, module_name)
+    methods = Expr[]
+
+    for node in ctx.dag.nodes
+        for i in eachindex(node.exprs)
+            expr = node.exprs[i]
+
+            # Check if this is a function
+            if @capture(expr, function name_(arg1_, args__) body_ end)
+                # Check if it's a zmq_msg_* function
+                if startswith(string(name), "zmq_msg_")
+                    # Replace occurrences of `arg::Ptr{zmq_msg_t}` with
+                    # `arg::Ref{Message}`.
+                    new_body = postwalk(body) do x
+                        if @capture(x, arg_name_::T_) && T == :(Ptr{zmq_msg_t})
+                            :($arg_name::Ref{Message})
+                        else
+                            x
+                        end
+                    end
+
+                    # Create the new method
+                    new_method = quote
+                        function $module_name.$name($arg1::Message, $(args...))
+                            $new_body
+                        end
+                    end
+
+                    push!(methods, prettify(new_method))
+                end
+            end
+        end
+    end
+
+    return methods
+end
+
+cd(@__DIR__) do
+    # Set the options
+    options = Clang.load_options(joinpath(@__DIR__, "generator.toml"))
+    header = joinpath(ZeroMQ_jll.artifact_dir, "include", "zmq.h")
+    args = Clang.get_default_args()
+
+    # Generate the generic bindings
+    ctx = Clang.create_context([header], args, options)
+    Clang.build!(ctx)
+
+    # Generate the Message methods we need
+    module_name = Symbol(options["general"]["module_name"])
+    msg_methods = get_msg_methods(ctx, module_name)
+    output_file = joinpath(@__DIR__, "../src/msg_bindings.jl")
+    open(output_file; write=true) do io
+        # Import symbols required by the bindings
+        write(io, "import ZeroMQ_jll: libzmq\n")
+        write(io, "import .lib: zmq_free_fn\n\n")
+
+        for expr in msg_methods
+            write(io, string(expr), "\n\n")
+        end
+    end
+end

--- a/gen/gen.jl
+++ b/gen/gen.jl
@@ -29,8 +29,8 @@ function get_msg_methods(ctx, module_name)
                     # Replace occurrences of `arg::Ptr{zmq_msg_t}` with
                     # `arg::Ref{Message}`.
                     new_body = postwalk(body) do x
-                        if @capture(x, arg_name_::T_) && T == :(Ptr{zmq_msg_t})
-                            :($arg_name::Ref{Message})
+                        if @capture(x, Ptr{T_}) && T == :(zmq_msg_t)
+                            :(Ref{Message})
                         else
                             x
                         end

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -13,6 +13,3 @@ prologue_file_path = "./prologue.jl"
 auto_mutability = true
 auto_mutability_with_new = false
 auto_mutability_includelist = ["zmq_pollitem_t"]
-
-[codegen]
-use_ccall_macro = true

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -1,0 +1,14 @@
+[general]
+library_name = "libzmq"
+module_name = "lib"
+output_file_path = "../src/bindings.jl"
+print_using_CEnum = false
+output_ignorelist = ["ZMQ_VERSION"]
+prologue_file_path = "./prologue.jl"
+
+auto_mutability = true
+auto_mutability_with_new = false
+auto_mutability_includelist = ["zmq_pollitem_t"]
+
+[codegen]
+use_ccall_macro = true

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -3,7 +3,11 @@ library_name = "libzmq"
 module_name = "lib"
 output_file_path = "../src/bindings.jl"
 print_using_CEnum = false
-output_ignorelist = ["ZMQ_VERSION"]
+output_ignorelist = ["ZMQ_VERSION", # This macro cannot be parsed by Clang.jl
+                     # These functions/types are deprecated
+                     "zmq_init", "zmq_term", "zmq_ctx_destroy",
+                     "zmq_device", "zmq_sendmsg", "zmq_recvmsg",
+                     "iovec", "zmq_sendiov", "zmq_recviov"]
 prologue_file_path = "./prologue.jl"
 
 auto_mutability = true

--- a/gen/prologue.jl
+++ b/gen/prologue.jl
@@ -1,0 +1,1 @@
+import ZeroMQ_jll: libzmq

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -1,7 +1,6 @@
 # Support for ZeroMQ, a network and interprocess communication library
 
 module ZMQ
-import ZeroMQ_jll: libzmq
 
 using Base.Libc: EAGAIN
 using FileWatching: UV_READABLE, uv_pollcb, FDWatcher
@@ -19,7 +18,7 @@ export
     #Sockets
     connect, bind, send, recv
 
-
+include("bindings.jl")
 include("constants.jl")
 include("optutil.jl")
 include("error.jl")
@@ -27,6 +26,7 @@ include("context.jl")
 include("socket.jl")
 include("sockopts.jl")
 include("message.jl")
+include("msg_bindings.jl")
 include("comm.jl")
 
 """
@@ -38,7 +38,7 @@ function lib_version()
     major = Ref{Cint}()
     minor = Ref{Cint}()
     patch = Ref{Cint}()
-    ccall((:zmq_version, libzmq), Cvoid, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major, minor, patch)
+    lib.zmq_version(major, minor, patch)
     return VersionNumber(major[], minor[], patch[])
 end
 

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -9,7 +9,7 @@ import ZeroMQ_jll: libzmq
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_errno.html).
 """
 function zmq_errno()
-    @ccall libzmq.zmq_errno()::Cint
+    ccall((:zmq_errno, libzmq), Cint, ())
 end
 
 """
@@ -18,7 +18,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_strerror.html).
 """
 function zmq_strerror(errnum_)
-    @ccall libzmq.zmq_strerror(errnum_::Cint)::Ptr{Cchar}
+    ccall((:zmq_strerror, libzmq), Ptr{Cchar}, (Cint,), errnum_)
 end
 
 """
@@ -27,7 +27,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_version.html).
 """
 function zmq_version(major_, minor_, patch_)
-    @ccall libzmq.zmq_version(major_::Ptr{Cint}, minor_::Ptr{Cint}, patch_::Ptr{Cint})::Cvoid
+    ccall((:zmq_version, libzmq), Cvoid, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major_, minor_, patch_)
 end
 
 """
@@ -36,7 +36,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_new.html).
 """
 function zmq_ctx_new()
-    @ccall libzmq.zmq_ctx_new()::Ptr{Cvoid}
+    ccall((:zmq_ctx_new, libzmq), Ptr{Cvoid}, ())
 end
 
 """
@@ -45,7 +45,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_term.html).
 """
 function zmq_ctx_term(context_)
-    @ccall libzmq.zmq_ctx_term(context_::Ptr{Cvoid})::Cint
+    ccall((:zmq_ctx_term, libzmq), Cint, (Ptr{Cvoid},), context_)
 end
 
 """
@@ -54,7 +54,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_shutdown.html).
 """
 function zmq_ctx_shutdown(context_)
-    @ccall libzmq.zmq_ctx_shutdown(context_::Ptr{Cvoid})::Cint
+    ccall((:zmq_ctx_shutdown, libzmq), Cint, (Ptr{Cvoid},), context_)
 end
 
 """
@@ -63,7 +63,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_set.html).
 """
 function zmq_ctx_set(context_, option_, optval_)
-    @ccall libzmq.zmq_ctx_set(context_::Ptr{Cvoid}, option_::Cint, optval_::Cint)::Cint
+    ccall((:zmq_ctx_set, libzmq), Cint, (Ptr{Cvoid}, Cint, Cint), context_, option_, optval_)
 end
 
 """
@@ -72,7 +72,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_get.html).
 """
 function zmq_ctx_get(context_, option_)
-    @ccall libzmq.zmq_ctx_get(context_::Ptr{Cvoid}, option_::Cint)::Cint
+    ccall((:zmq_ctx_get, libzmq), Cint, (Ptr{Cvoid}, Cint), context_, option_)
 end
 
 struct zmq_msg_t
@@ -104,7 +104,7 @@ const zmq_free_fn = Cvoid
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init.html).
 """
 function zmq_msg_init(msg_)
-    @ccall libzmq.zmq_msg_init(msg_::Ptr{zmq_msg_t})::Cint
+    ccall((:zmq_msg_init, libzmq), Cint, (Ptr{zmq_msg_t},), msg_)
 end
 
 """
@@ -113,7 +113,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init_size.html).
 """
 function zmq_msg_init_size(msg_, size_)
-    @ccall libzmq.zmq_msg_init_size(msg_::Ptr{zmq_msg_t}, size_::Csize_t)::Cint
+    ccall((:zmq_msg_init_size, libzmq), Cint, (Ptr{zmq_msg_t}, Csize_t), msg_, size_)
 end
 
 """
@@ -122,7 +122,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init_data.html).
 """
 function zmq_msg_init_data(msg_, data_, size_, ffn_, hint_)
-    @ccall libzmq.zmq_msg_init_data(msg_::Ptr{zmq_msg_t}, data_::Ptr{Cvoid}, size_::Csize_t, ffn_::Ptr{zmq_free_fn}, hint_::Ptr{Cvoid})::Cint
+    ccall((:zmq_msg_init_data, libzmq), Cint, (Ptr{zmq_msg_t}, Ptr{Cvoid}, Csize_t, Ptr{zmq_free_fn}, Ptr{Cvoid}), msg_, data_, size_, ffn_, hint_)
 end
 
 """
@@ -131,7 +131,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_send.html).
 """
 function zmq_msg_send(msg_, s_, flags_)
-    @ccall libzmq.zmq_msg_send(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+    ccall((:zmq_msg_send, libzmq), Cint, (Ptr{zmq_msg_t}, Ptr{Cvoid}, Cint), msg_, s_, flags_)
 end
 
 """
@@ -140,7 +140,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_recv.html).
 """
 function zmq_msg_recv(msg_, s_, flags_)
-    @ccall libzmq.zmq_msg_recv(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+    ccall((:zmq_msg_recv, libzmq), Cint, (Ptr{zmq_msg_t}, Ptr{Cvoid}, Cint), msg_, s_, flags_)
 end
 
 """
@@ -149,7 +149,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_close.html).
 """
 function zmq_msg_close(msg_)
-    @ccall libzmq.zmq_msg_close(msg_::Ptr{zmq_msg_t})::Cint
+    ccall((:zmq_msg_close, libzmq), Cint, (Ptr{zmq_msg_t},), msg_)
 end
 
 """
@@ -158,7 +158,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_move.html).
 """
 function zmq_msg_move(dest_, src_)
-    @ccall libzmq.zmq_msg_move(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
+    ccall((:zmq_msg_move, libzmq), Cint, (Ptr{zmq_msg_t}, Ptr{zmq_msg_t}), dest_, src_)
 end
 
 """
@@ -167,7 +167,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_copy.html).
 """
 function zmq_msg_copy(dest_, src_)
-    @ccall libzmq.zmq_msg_copy(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
+    ccall((:zmq_msg_copy, libzmq), Cint, (Ptr{zmq_msg_t}, Ptr{zmq_msg_t}), dest_, src_)
 end
 
 """
@@ -176,7 +176,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_data.html).
 """
 function zmq_msg_data(msg_)
-    @ccall libzmq.zmq_msg_data(msg_::Ptr{zmq_msg_t})::Ptr{Cvoid}
+    ccall((:zmq_msg_data, libzmq), Ptr{Cvoid}, (Ptr{zmq_msg_t},), msg_)
 end
 
 """
@@ -185,7 +185,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_size.html).
 """
 function zmq_msg_size(msg_)
-    @ccall libzmq.zmq_msg_size(msg_::Ptr{zmq_msg_t})::Csize_t
+    ccall((:zmq_msg_size, libzmq), Csize_t, (Ptr{zmq_msg_t},), msg_)
 end
 
 """
@@ -194,7 +194,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_more.html).
 """
 function zmq_msg_more(msg_)
-    @ccall libzmq.zmq_msg_more(msg_::Ptr{zmq_msg_t})::Cint
+    ccall((:zmq_msg_more, libzmq), Cint, (Ptr{zmq_msg_t},), msg_)
 end
 
 """
@@ -203,7 +203,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_get.html).
 """
 function zmq_msg_get(msg_, property_)
-    @ccall libzmq.zmq_msg_get(msg_::Ptr{zmq_msg_t}, property_::Cint)::Cint
+    ccall((:zmq_msg_get, libzmq), Cint, (Ptr{zmq_msg_t}, Cint), msg_, property_)
 end
 
 """
@@ -212,7 +212,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_set.html).
 """
 function zmq_msg_set(msg_, property_, optval_)
-    @ccall libzmq.zmq_msg_set(msg_::Ptr{zmq_msg_t}, property_::Cint, optval_::Cint)::Cint
+    ccall((:zmq_msg_set, libzmq), Cint, (Ptr{zmq_msg_t}, Cint, Cint), msg_, property_, optval_)
 end
 
 """
@@ -221,7 +221,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_gets.html).
 """
 function zmq_msg_gets(msg_, property_)
-    @ccall libzmq.zmq_msg_gets(msg_::Ptr{zmq_msg_t}, property_::Ptr{Cchar})::Ptr{Cchar}
+    ccall((:zmq_msg_gets, libzmq), Ptr{Cchar}, (Ptr{zmq_msg_t}, Ptr{Cchar}), msg_, property_)
 end
 
 """
@@ -230,7 +230,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_socket.html).
 """
 function zmq_socket(arg1, type_)
-    @ccall libzmq.zmq_socket(arg1::Ptr{Cvoid}, type_::Cint)::Ptr{Cvoid}
+    ccall((:zmq_socket, libzmq), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), arg1, type_)
 end
 
 """
@@ -239,7 +239,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_close.html).
 """
 function zmq_close(s_)
-    @ccall libzmq.zmq_close(s_::Ptr{Cvoid})::Cint
+    ccall((:zmq_close, libzmq), Cint, (Ptr{Cvoid},), s_)
 end
 
 """
@@ -248,7 +248,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_setsockopt.html).
 """
 function zmq_setsockopt(s_, option_, optval_, optvallen_)
-    @ccall libzmq.zmq_setsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Csize_t)::Cint
+    ccall((:zmq_setsockopt, libzmq), Cint, (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Csize_t), s_, option_, optval_, optvallen_)
 end
 
 """
@@ -257,7 +257,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_getsockopt.html).
 """
 function zmq_getsockopt(s_, option_, optval_, optvallen_)
-    @ccall libzmq.zmq_getsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Ptr{Csize_t})::Cint
+    ccall((:zmq_getsockopt, libzmq), Cint, (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Ptr{Csize_t}), s_, option_, optval_, optvallen_)
 end
 
 """
@@ -266,7 +266,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_bind.html).
 """
 function zmq_bind(s_, addr_)
-    @ccall libzmq.zmq_bind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+    ccall((:zmq_bind, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cchar}), s_, addr_)
 end
 
 """
@@ -275,7 +275,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_connect.html).
 """
 function zmq_connect(s_, addr_)
-    @ccall libzmq.zmq_connect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+    ccall((:zmq_connect, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cchar}), s_, addr_)
 end
 
 """
@@ -284,7 +284,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_unbind.html).
 """
 function zmq_unbind(s_, addr_)
-    @ccall libzmq.zmq_unbind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+    ccall((:zmq_unbind, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cchar}), s_, addr_)
 end
 
 """
@@ -293,7 +293,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_disconnect.html).
 """
 function zmq_disconnect(s_, addr_)
-    @ccall libzmq.zmq_disconnect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+    ccall((:zmq_disconnect, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cchar}), s_, addr_)
 end
 
 """
@@ -302,7 +302,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_send.html).
 """
 function zmq_send(s_, buf_, len_, flags_)
-    @ccall libzmq.zmq_send(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+    ccall((:zmq_send, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Cint), s_, buf_, len_, flags_)
 end
 
 """
@@ -311,7 +311,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_send_const.html).
 """
 function zmq_send_const(s_, buf_, len_, flags_)
-    @ccall libzmq.zmq_send_const(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+    ccall((:zmq_send_const, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Cint), s_, buf_, len_, flags_)
 end
 
 """
@@ -320,7 +320,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_recv.html).
 """
 function zmq_recv(s_, buf_, len_, flags_)
-    @ccall libzmq.zmq_recv(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+    ccall((:zmq_recv, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Cint), s_, buf_, len_, flags_)
 end
 
 """
@@ -329,7 +329,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_socket_monitor.html).
 """
 function zmq_socket_monitor(s_, addr_, events_)
-    @ccall libzmq.zmq_socket_monitor(s_::Ptr{Cvoid}, addr_::Ptr{Cchar}, events_::Cint)::Cint
+    ccall((:zmq_socket_monitor, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cchar}, Cint), s_, addr_, events_)
 end
 
 const zmq_fd_t = Cint
@@ -347,7 +347,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_poll.html).
 """
 function zmq_poll(items_, nitems_, timeout_)
-    @ccall libzmq.zmq_poll(items_::Ptr{zmq_pollitem_t}, nitems_::Cint, timeout_::Clong)::Cint
+    ccall((:zmq_poll, libzmq), Cint, (Ptr{zmq_pollitem_t}, Cint, Clong), items_, nitems_, timeout_)
 end
 
 """
@@ -356,7 +356,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_proxy.html).
 """
 function zmq_proxy(frontend_, backend_, capture_)
-    @ccall libzmq.zmq_proxy(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid})::Cint
+    ccall((:zmq_proxy, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), frontend_, backend_, capture_)
 end
 
 """
@@ -365,7 +365,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_proxy_steerable.html).
 """
 function zmq_proxy_steerable(frontend_, backend_, capture_, control_)
-    @ccall libzmq.zmq_proxy_steerable(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid}, control_::Ptr{Cvoid})::Cint
+    ccall((:zmq_proxy_steerable, libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}), frontend_, backend_, capture_, control_)
 end
 
 """
@@ -374,7 +374,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_has.html).
 """
 function zmq_has(capability_)
-    @ccall libzmq.zmq_has(capability_::Ptr{Cchar})::Cint
+    ccall((:zmq_has, libzmq), Cint, (Ptr{Cchar},), capability_)
 end
 
 """
@@ -383,7 +383,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_z85_encode.html).
 """
 function zmq_z85_encode(dest_, data_, size_)
-    @ccall libzmq.zmq_z85_encode(dest_::Ptr{Cchar}, data_::Ptr{UInt8}, size_::Csize_t)::Ptr{Cchar}
+    ccall((:zmq_z85_encode, libzmq), Ptr{Cchar}, (Ptr{Cchar}, Ptr{UInt8}, Csize_t), dest_, data_, size_)
 end
 
 """
@@ -392,7 +392,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_z85_decode.html).
 """
 function zmq_z85_decode(dest_, string_)
-    @ccall libzmq.zmq_z85_decode(dest_::Ptr{UInt8}, string_::Ptr{Cchar})::Ptr{UInt8}
+    ccall((:zmq_z85_decode, libzmq), Ptr{UInt8}, (Ptr{UInt8}, Ptr{Cchar}), dest_, string_)
 end
 
 """
@@ -401,7 +401,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_curve_keypair.html).
 """
 function zmq_curve_keypair(z85_public_key_, z85_secret_key_)
-    @ccall libzmq.zmq_curve_keypair(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
+    ccall((:zmq_curve_keypair, libzmq), Cint, (Ptr{Cchar}, Ptr{Cchar}), z85_public_key_, z85_secret_key_)
 end
 
 """
@@ -410,7 +410,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_curve_public.html).
 """
 function zmq_curve_public(z85_public_key_, z85_secret_key_)
-    @ccall libzmq.zmq_curve_public(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
+    ccall((:zmq_curve_public, libzmq), Cint, (Ptr{Cchar}, Ptr{Cchar}), z85_public_key_, z85_secret_key_)
 end
 
 """
@@ -419,7 +419,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_new.html).
 """
 function zmq_atomic_counter_new()
-    @ccall libzmq.zmq_atomic_counter_new()::Ptr{Cvoid}
+    ccall((:zmq_atomic_counter_new, libzmq), Ptr{Cvoid}, ())
 end
 
 """
@@ -428,7 +428,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_set.html).
 """
 function zmq_atomic_counter_set(counter_, value_)
-    @ccall libzmq.zmq_atomic_counter_set(counter_::Ptr{Cvoid}, value_::Cint)::Cvoid
+    ccall((:zmq_atomic_counter_set, libzmq), Cvoid, (Ptr{Cvoid}, Cint), counter_, value_)
 end
 
 """
@@ -437,7 +437,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_inc.html).
 """
 function zmq_atomic_counter_inc(counter_)
-    @ccall libzmq.zmq_atomic_counter_inc(counter_::Ptr{Cvoid})::Cint
+    ccall((:zmq_atomic_counter_inc, libzmq), Cint, (Ptr{Cvoid},), counter_)
 end
 
 """
@@ -446,7 +446,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_dec.html).
 """
 function zmq_atomic_counter_dec(counter_)
-    @ccall libzmq.zmq_atomic_counter_dec(counter_::Ptr{Cvoid})::Cint
+    ccall((:zmq_atomic_counter_dec, libzmq), Cint, (Ptr{Cvoid},), counter_)
 end
 
 """
@@ -455,7 +455,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_value.html).
 """
 function zmq_atomic_counter_value(counter_)
-    @ccall libzmq.zmq_atomic_counter_value(counter_::Ptr{Cvoid})::Cint
+    ccall((:zmq_atomic_counter_value, libzmq), Cint, (Ptr{Cvoid},), counter_)
 end
 
 """
@@ -464,7 +464,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_destroy.html).
 """
 function zmq_atomic_counter_destroy(counter_p_)
-    @ccall libzmq.zmq_atomic_counter_destroy(counter_p_::Ptr{Ptr{Cvoid}})::Cvoid
+    ccall((:zmq_atomic_counter_destroy, libzmq), Cvoid, (Ptr{Ptr{Cvoid}},), counter_p_)
 end
 
 # typedef void ( zmq_timer_fn ) ( int timer_id , void * arg )
@@ -476,7 +476,7 @@ const zmq_timer_fn = Cvoid
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_new()
-    @ccall libzmq.zmq_timers_new()::Ptr{Cvoid}
+    ccall((:zmq_timers_new, libzmq), Ptr{Cvoid}, ())
 end
 
 """
@@ -485,7 +485,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_destroy(timers_p)
-    @ccall libzmq.zmq_timers_destroy(timers_p::Ptr{Ptr{Cvoid}})::Cint
+    ccall((:zmq_timers_destroy, libzmq), Cint, (Ptr{Ptr{Cvoid}},), timers_p)
 end
 
 """
@@ -494,7 +494,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_add(timers, interval, handler, arg)
-    @ccall libzmq.zmq_timers_add(timers::Ptr{Cvoid}, interval::Csize_t, handler::zmq_timer_fn, arg::Ptr{Cvoid})::Cint
+    ccall((:zmq_timers_add, libzmq), Cint, (Ptr{Cvoid}, Csize_t, zmq_timer_fn, Ptr{Cvoid}), timers, interval, handler, arg)
 end
 
 """
@@ -503,7 +503,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_cancel(timers, timer_id)
-    @ccall libzmq.zmq_timers_cancel(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
+    ccall((:zmq_timers_cancel, libzmq), Cint, (Ptr{Cvoid}, Cint), timers, timer_id)
 end
 
 """
@@ -512,7 +512,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_set_interval(timers, timer_id, interval)
-    @ccall libzmq.zmq_timers_set_interval(timers::Ptr{Cvoid}, timer_id::Cint, interval::Csize_t)::Cint
+    ccall((:zmq_timers_set_interval, libzmq), Cint, (Ptr{Cvoid}, Cint, Csize_t), timers, timer_id, interval)
 end
 
 """
@@ -521,7 +521,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_reset(timers, timer_id)
-    @ccall libzmq.zmq_timers_reset(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
+    ccall((:zmq_timers_reset, libzmq), Cint, (Ptr{Cvoid}, Cint), timers, timer_id)
 end
 
 """
@@ -530,7 +530,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_timeout(timers)
-    @ccall libzmq.zmq_timers_timeout(timers::Ptr{Cvoid})::Clong
+    ccall((:zmq_timers_timeout, libzmq), Clong, (Ptr{Cvoid},), timers)
 end
 
 """
@@ -539,7 +539,7 @@ end
 [Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
 """
 function zmq_timers_execute(timers)
-    @ccall libzmq.zmq_timers_execute(timers::Ptr{Cvoid})::Cint
+    ccall((:zmq_timers_execute, libzmq), Cint, (Ptr{Cvoid},), timers)
 end
 
 """
@@ -548,7 +548,7 @@ end
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_stopwatch_start()
-    @ccall libzmq.zmq_stopwatch_start()::Ptr{Cvoid}
+    ccall((:zmq_stopwatch_start, libzmq), Ptr{Cvoid}, ())
 end
 
 """
@@ -557,7 +557,7 @@ end
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_stopwatch_intermediate(watch_)
-    @ccall libzmq.zmq_stopwatch_intermediate(watch_::Ptr{Cvoid})::Culong
+    ccall((:zmq_stopwatch_intermediate, libzmq), Culong, (Ptr{Cvoid},), watch_)
 end
 
 """
@@ -566,7 +566,7 @@ end
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_stopwatch_stop(watch_)
-    @ccall libzmq.zmq_stopwatch_stop(watch_::Ptr{Cvoid})::Culong
+    ccall((:zmq_stopwatch_stop, libzmq), Culong, (Ptr{Cvoid},), watch_)
 end
 
 """
@@ -575,7 +575,7 @@ end
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_sleep(seconds_)
-    @ccall libzmq.zmq_sleep(seconds_::Cint)::Cvoid
+    ccall((:zmq_sleep, libzmq), Cvoid, (Cint,), seconds_)
 end
 
 # typedef void ( zmq_thread_fn ) ( void * )
@@ -587,7 +587,7 @@ const zmq_thread_fn = Cvoid
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_threadstart(func_, arg_)
-    @ccall libzmq.zmq_threadstart(func_::Ptr{zmq_thread_fn}, arg_::Ptr{Cvoid})::Ptr{Cvoid}
+    ccall((:zmq_threadstart, libzmq), Ptr{Cvoid}, (Ptr{zmq_thread_fn}, Ptr{Cvoid}), func_, arg_)
 end
 
 """
@@ -596,7 +596,7 @@ end
 This is an undocumented function, not part of the formal ZMQ API.
 """
 function zmq_threadclose(thread_)
-    @ccall libzmq.zmq_threadclose(thread_::Ptr{Cvoid})::Cvoid
+    ccall((:zmq_threadclose, libzmq), Cvoid, (Ptr{Cvoid},), thread_)
 end
 
 const ZMQ_VERSION_MAJOR = 4

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -3,48 +3,76 @@ module lib
 import ZeroMQ_jll: libzmq
 
 
+"""
+    zmq_errno()
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_errno.html).
+"""
 function zmq_errno()
     @ccall libzmq.zmq_errno()::Cint
 end
 
+"""
+    zmq_strerror(errnum_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_strerror.html).
+"""
 function zmq_strerror(errnum_)
     @ccall libzmq.zmq_strerror(errnum_::Cint)::Ptr{Cchar}
 end
 
+"""
+    zmq_version(major_, minor_, patch_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_version.html).
+"""
 function zmq_version(major_, minor_, patch_)
     @ccall libzmq.zmq_version(major_::Ptr{Cint}, minor_::Ptr{Cint}, patch_::Ptr{Cint})::Cvoid
 end
 
+"""
+    zmq_ctx_new()
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_new.html).
+"""
 function zmq_ctx_new()
     @ccall libzmq.zmq_ctx_new()::Ptr{Cvoid}
 end
 
+"""
+    zmq_ctx_term(context_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_term.html).
+"""
 function zmq_ctx_term(context_)
     @ccall libzmq.zmq_ctx_term(context_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_ctx_shutdown(context_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_shutdown.html).
+"""
 function zmq_ctx_shutdown(context_)
     @ccall libzmq.zmq_ctx_shutdown(context_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_ctx_set(context_, option_, optval_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_set.html).
+"""
 function zmq_ctx_set(context_, option_, optval_)
     @ccall libzmq.zmq_ctx_set(context_::Ptr{Cvoid}, option_::Cint, optval_::Cint)::Cint
 end
 
+"""
+    zmq_ctx_get(context_, option_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_ctx_get.html).
+"""
 function zmq_ctx_get(context_, option_)
     @ccall libzmq.zmq_ctx_get(context_::Ptr{Cvoid}, option_::Cint)::Cint
-end
-
-function zmq_init(io_threads_)
-    @ccall libzmq.zmq_init(io_threads_::Cint)::Ptr{Cvoid}
-end
-
-function zmq_term(context_)
-    @ccall libzmq.zmq_term(context_::Ptr{Cvoid})::Cint
-end
-
-function zmq_ctx_destroy(context_)
-    @ccall libzmq.zmq_ctx_destroy(context_::Ptr{Cvoid})::Cint
 end
 
 struct zmq_msg_t
@@ -70,106 +98,236 @@ end
 # typedef void ( zmq_free_fn ) ( void * data_ , void * hint_ )
 const zmq_free_fn = Cvoid
 
+"""
+    zmq_msg_init(msg_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init.html).
+"""
 function zmq_msg_init(msg_)
     @ccall libzmq.zmq_msg_init(msg_::Ptr{zmq_msg_t})::Cint
 end
 
+"""
+    zmq_msg_init_size(msg_, size_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init_size.html).
+"""
 function zmq_msg_init_size(msg_, size_)
     @ccall libzmq.zmq_msg_init_size(msg_::Ptr{zmq_msg_t}, size_::Csize_t)::Cint
 end
 
+"""
+    zmq_msg_init_data(msg_, data_, size_, ffn_, hint_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_init_data.html).
+"""
 function zmq_msg_init_data(msg_, data_, size_, ffn_, hint_)
     @ccall libzmq.zmq_msg_init_data(msg_::Ptr{zmq_msg_t}, data_::Ptr{Cvoid}, size_::Csize_t, ffn_::Ptr{zmq_free_fn}, hint_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_msg_send(msg_, s_, flags_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_send.html).
+"""
 function zmq_msg_send(msg_, s_, flags_)
     @ccall libzmq.zmq_msg_send(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
 end
 
+"""
+    zmq_msg_recv(msg_, s_, flags_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_recv.html).
+"""
 function zmq_msg_recv(msg_, s_, flags_)
     @ccall libzmq.zmq_msg_recv(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
 end
 
+"""
+    zmq_msg_close(msg_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_close.html).
+"""
 function zmq_msg_close(msg_)
     @ccall libzmq.zmq_msg_close(msg_::Ptr{zmq_msg_t})::Cint
 end
 
+"""
+    zmq_msg_move(dest_, src_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_move.html).
+"""
 function zmq_msg_move(dest_, src_)
     @ccall libzmq.zmq_msg_move(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
 end
 
+"""
+    zmq_msg_copy(dest_, src_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_copy.html).
+"""
 function zmq_msg_copy(dest_, src_)
     @ccall libzmq.zmq_msg_copy(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
 end
 
+"""
+    zmq_msg_data(msg_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_data.html).
+"""
 function zmq_msg_data(msg_)
     @ccall libzmq.zmq_msg_data(msg_::Ptr{zmq_msg_t})::Ptr{Cvoid}
 end
 
+"""
+    zmq_msg_size(msg_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_size.html).
+"""
 function zmq_msg_size(msg_)
     @ccall libzmq.zmq_msg_size(msg_::Ptr{zmq_msg_t})::Csize_t
 end
 
+"""
+    zmq_msg_more(msg_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_more.html).
+"""
 function zmq_msg_more(msg_)
     @ccall libzmq.zmq_msg_more(msg_::Ptr{zmq_msg_t})::Cint
 end
 
+"""
+    zmq_msg_get(msg_, property_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_get.html).
+"""
 function zmq_msg_get(msg_, property_)
     @ccall libzmq.zmq_msg_get(msg_::Ptr{zmq_msg_t}, property_::Cint)::Cint
 end
 
+"""
+    zmq_msg_set(msg_, property_, optval_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_set.html).
+"""
 function zmq_msg_set(msg_, property_, optval_)
     @ccall libzmq.zmq_msg_set(msg_::Ptr{zmq_msg_t}, property_::Cint, optval_::Cint)::Cint
 end
 
+"""
+    zmq_msg_gets(msg_, property_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_msg_gets.html).
+"""
 function zmq_msg_gets(msg_, property_)
     @ccall libzmq.zmq_msg_gets(msg_::Ptr{zmq_msg_t}, property_::Ptr{Cchar})::Ptr{Cchar}
 end
 
+"""
+    zmq_socket(arg1, type_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_socket.html).
+"""
 function zmq_socket(arg1, type_)
     @ccall libzmq.zmq_socket(arg1::Ptr{Cvoid}, type_::Cint)::Ptr{Cvoid}
 end
 
+"""
+    zmq_close(s_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_close.html).
+"""
 function zmq_close(s_)
     @ccall libzmq.zmq_close(s_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_setsockopt(s_, option_, optval_, optvallen_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_setsockopt.html).
+"""
 function zmq_setsockopt(s_, option_, optval_, optvallen_)
     @ccall libzmq.zmq_setsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Csize_t)::Cint
 end
 
+"""
+    zmq_getsockopt(s_, option_, optval_, optvallen_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_getsockopt.html).
+"""
 function zmq_getsockopt(s_, option_, optval_, optvallen_)
     @ccall libzmq.zmq_getsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Ptr{Csize_t})::Cint
 end
 
+"""
+    zmq_bind(s_, addr_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_bind.html).
+"""
 function zmq_bind(s_, addr_)
     @ccall libzmq.zmq_bind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_connect(s_, addr_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_connect.html).
+"""
 function zmq_connect(s_, addr_)
     @ccall libzmq.zmq_connect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_unbind(s_, addr_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_unbind.html).
+"""
 function zmq_unbind(s_, addr_)
     @ccall libzmq.zmq_unbind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_disconnect(s_, addr_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_disconnect.html).
+"""
 function zmq_disconnect(s_, addr_)
     @ccall libzmq.zmq_disconnect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_send(s_, buf_, len_, flags_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_send.html).
+"""
 function zmq_send(s_, buf_, len_, flags_)
     @ccall libzmq.zmq_send(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
 end
 
+"""
+    zmq_send_const(s_, buf_, len_, flags_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_send_const.html).
+"""
 function zmq_send_const(s_, buf_, len_, flags_)
     @ccall libzmq.zmq_send_const(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
 end
 
+"""
+    zmq_recv(s_, buf_, len_, flags_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_recv.html).
+"""
 function zmq_recv(s_, buf_, len_, flags_)
     @ccall libzmq.zmq_recv(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
 end
 
+"""
+    zmq_socket_monitor(s_, addr_, events_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_socket_monitor.html).
+"""
 function zmq_socket_monitor(s_, addr_, events_)
     @ccall libzmq.zmq_socket_monitor(s_::Ptr{Cvoid}, addr_::Ptr{Cchar}, events_::Cint)::Cint
 end
@@ -183,80 +341,128 @@ mutable struct zmq_pollitem_t
     revents::Cshort
 end
 
+"""
+    zmq_poll(items_, nitems_, timeout_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_poll.html).
+"""
 function zmq_poll(items_, nitems_, timeout_)
     @ccall libzmq.zmq_poll(items_::Ptr{zmq_pollitem_t}, nitems_::Cint, timeout_::Clong)::Cint
 end
 
+"""
+    zmq_proxy(frontend_, backend_, capture_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_proxy.html).
+"""
 function zmq_proxy(frontend_, backend_, capture_)
     @ccall libzmq.zmq_proxy(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_proxy_steerable(frontend_, backend_, capture_, control_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_proxy_steerable.html).
+"""
 function zmq_proxy_steerable(frontend_, backend_, capture_, control_)
     @ccall libzmq.zmq_proxy_steerable(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid}, control_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_has(capability_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_has.html).
+"""
 function zmq_has(capability_)
     @ccall libzmq.zmq_has(capability_::Ptr{Cchar})::Cint
 end
 
-function zmq_device(type_, frontend_, backend_)
-    @ccall libzmq.zmq_device(type_::Cint, frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid})::Cint
-end
+"""
+    zmq_z85_encode(dest_, data_, size_)
 
-function zmq_sendmsg(s_, msg_, flags_)
-    @ccall libzmq.zmq_sendmsg(s_::Ptr{Cvoid}, msg_::Ptr{zmq_msg_t}, flags_::Cint)::Cint
-end
-
-function zmq_recvmsg(s_, msg_, flags_)
-    @ccall libzmq.zmq_recvmsg(s_::Ptr{Cvoid}, msg_::Ptr{zmq_msg_t}, flags_::Cint)::Cint
-end
-
-mutable struct iovec end
-
-function zmq_sendiov(s_, iov_, count_, flags_)
-    @ccall libzmq.zmq_sendiov(s_::Ptr{Cvoid}, iov_::Ptr{iovec}, count_::Csize_t, flags_::Cint)::Cint
-end
-
-function zmq_recviov(s_, iov_, count_, flags_)
-    @ccall libzmq.zmq_recviov(s_::Ptr{Cvoid}, iov_::Ptr{iovec}, count_::Ptr{Csize_t}, flags_::Cint)::Cint
-end
-
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_z85_encode.html).
+"""
 function zmq_z85_encode(dest_, data_, size_)
     @ccall libzmq.zmq_z85_encode(dest_::Ptr{Cchar}, data_::Ptr{UInt8}, size_::Csize_t)::Ptr{Cchar}
 end
 
+"""
+    zmq_z85_decode(dest_, string_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_z85_decode.html).
+"""
 function zmq_z85_decode(dest_, string_)
     @ccall libzmq.zmq_z85_decode(dest_::Ptr{UInt8}, string_::Ptr{Cchar})::Ptr{UInt8}
 end
 
+"""
+    zmq_curve_keypair(z85_public_key_, z85_secret_key_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_curve_keypair.html).
+"""
 function zmq_curve_keypair(z85_public_key_, z85_secret_key_)
     @ccall libzmq.zmq_curve_keypair(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_curve_public(z85_public_key_, z85_secret_key_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_curve_public.html).
+"""
 function zmq_curve_public(z85_public_key_, z85_secret_key_)
     @ccall libzmq.zmq_curve_public(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
 end
 
+"""
+    zmq_atomic_counter_new()
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_new.html).
+"""
 function zmq_atomic_counter_new()
     @ccall libzmq.zmq_atomic_counter_new()::Ptr{Cvoid}
 end
 
+"""
+    zmq_atomic_counter_set(counter_, value_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_set.html).
+"""
 function zmq_atomic_counter_set(counter_, value_)
     @ccall libzmq.zmq_atomic_counter_set(counter_::Ptr{Cvoid}, value_::Cint)::Cvoid
 end
 
+"""
+    zmq_atomic_counter_inc(counter_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_inc.html).
+"""
 function zmq_atomic_counter_inc(counter_)
     @ccall libzmq.zmq_atomic_counter_inc(counter_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_atomic_counter_dec(counter_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_dec.html).
+"""
 function zmq_atomic_counter_dec(counter_)
     @ccall libzmq.zmq_atomic_counter_dec(counter_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_atomic_counter_value(counter_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_value.html).
+"""
 function zmq_atomic_counter_value(counter_)
     @ccall libzmq.zmq_atomic_counter_value(counter_::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_atomic_counter_destroy(counter_p_)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_atomic_counter_destroy.html).
+"""
 function zmq_atomic_counter_destroy(counter_p_)
     @ccall libzmq.zmq_atomic_counter_destroy(counter_p_::Ptr{Ptr{Cvoid}})::Cvoid
 end
@@ -264,50 +470,110 @@ end
 # typedef void ( zmq_timer_fn ) ( int timer_id , void * arg )
 const zmq_timer_fn = Cvoid
 
+"""
+    zmq_timers_new()
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_new()
     @ccall libzmq.zmq_timers_new()::Ptr{Cvoid}
 end
 
+"""
+    zmq_timers_destroy(timers_p)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_destroy(timers_p)
     @ccall libzmq.zmq_timers_destroy(timers_p::Ptr{Ptr{Cvoid}})::Cint
 end
 
+"""
+    zmq_timers_add(timers, interval, handler, arg)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_add(timers, interval, handler, arg)
     @ccall libzmq.zmq_timers_add(timers::Ptr{Cvoid}, interval::Csize_t, handler::zmq_timer_fn, arg::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_timers_cancel(timers, timer_id)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_cancel(timers, timer_id)
     @ccall libzmq.zmq_timers_cancel(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
 end
 
+"""
+    zmq_timers_set_interval(timers, timer_id, interval)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_set_interval(timers, timer_id, interval)
     @ccall libzmq.zmq_timers_set_interval(timers::Ptr{Cvoid}, timer_id::Cint, interval::Csize_t)::Cint
 end
 
+"""
+    zmq_timers_reset(timers, timer_id)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_reset(timers, timer_id)
     @ccall libzmq.zmq_timers_reset(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
 end
 
+"""
+    zmq_timers_timeout(timers)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_timeout(timers)
     @ccall libzmq.zmq_timers_timeout(timers::Ptr{Cvoid})::Clong
 end
 
+"""
+    zmq_timers_execute(timers)
+
+[Upstream documentation](https://libzmq.readthedocs.io/en/latest/zmq_timers.html).
+"""
 function zmq_timers_execute(timers)
     @ccall libzmq.zmq_timers_execute(timers::Ptr{Cvoid})::Cint
 end
 
+"""
+    zmq_stopwatch_start()
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_stopwatch_start()
     @ccall libzmq.zmq_stopwatch_start()::Ptr{Cvoid}
 end
 
+"""
+    zmq_stopwatch_intermediate(watch_)
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_stopwatch_intermediate(watch_)
     @ccall libzmq.zmq_stopwatch_intermediate(watch_::Ptr{Cvoid})::Culong
 end
 
+"""
+    zmq_stopwatch_stop(watch_)
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_stopwatch_stop(watch_)
     @ccall libzmq.zmq_stopwatch_stop(watch_::Ptr{Cvoid})::Culong
 end
 
+"""
+    zmq_sleep(seconds_)
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_sleep(seconds_)
     @ccall libzmq.zmq_sleep(seconds_::Cint)::Cvoid
 end
@@ -315,10 +581,20 @@ end
 # typedef void ( zmq_thread_fn ) ( void * )
 const zmq_thread_fn = Cvoid
 
+"""
+    zmq_threadstart(func_, arg_)
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_threadstart(func_, arg_)
     @ccall libzmq.zmq_threadstart(func_::Ptr{zmq_thread_fn}, arg_::Ptr{Cvoid})::Ptr{Cvoid}
 end
 
+"""
+    zmq_threadclose(thread_)
+
+This is an undocumented function, not part of the formal ZMQ API.
+"""
 function zmq_threadclose(thread_)
     @ccall libzmq.zmq_threadclose(thread_::Ptr{Cvoid})::Cvoid
 end

--- a/src/bindings.jl
+++ b/src/bindings.jl
@@ -1,0 +1,694 @@
+module lib
+
+import ZeroMQ_jll: libzmq
+
+
+function zmq_errno()
+    @ccall libzmq.zmq_errno()::Cint
+end
+
+function zmq_strerror(errnum_)
+    @ccall libzmq.zmq_strerror(errnum_::Cint)::Ptr{Cchar}
+end
+
+function zmq_version(major_, minor_, patch_)
+    @ccall libzmq.zmq_version(major_::Ptr{Cint}, minor_::Ptr{Cint}, patch_::Ptr{Cint})::Cvoid
+end
+
+function zmq_ctx_new()
+    @ccall libzmq.zmq_ctx_new()::Ptr{Cvoid}
+end
+
+function zmq_ctx_term(context_)
+    @ccall libzmq.zmq_ctx_term(context_::Ptr{Cvoid})::Cint
+end
+
+function zmq_ctx_shutdown(context_)
+    @ccall libzmq.zmq_ctx_shutdown(context_::Ptr{Cvoid})::Cint
+end
+
+function zmq_ctx_set(context_, option_, optval_)
+    @ccall libzmq.zmq_ctx_set(context_::Ptr{Cvoid}, option_::Cint, optval_::Cint)::Cint
+end
+
+function zmq_ctx_get(context_, option_)
+    @ccall libzmq.zmq_ctx_get(context_::Ptr{Cvoid}, option_::Cint)::Cint
+end
+
+function zmq_init(io_threads_)
+    @ccall libzmq.zmq_init(io_threads_::Cint)::Ptr{Cvoid}
+end
+
+function zmq_term(context_)
+    @ccall libzmq.zmq_term(context_::Ptr{Cvoid})::Cint
+end
+
+function zmq_ctx_destroy(context_)
+    @ccall libzmq.zmq_ctx_destroy(context_::Ptr{Cvoid})::Cint
+end
+
+struct zmq_msg_t
+    data::NTuple{64, UInt8}
+end
+
+function Base.getproperty(x::Ptr{zmq_msg_t}, f::Symbol)
+    f === :_ && return Ptr{NTuple{64, Cuchar}}(x + 0)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::zmq_msg_t, f::Symbol)
+    r = Ref{zmq_msg_t}(x)
+    ptr = Base.unsafe_convert(Ptr{zmq_msg_t}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{zmq_msg_t}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+# typedef void ( zmq_free_fn ) ( void * data_ , void * hint_ )
+const zmq_free_fn = Cvoid
+
+function zmq_msg_init(msg_)
+    @ccall libzmq.zmq_msg_init(msg_::Ptr{zmq_msg_t})::Cint
+end
+
+function zmq_msg_init_size(msg_, size_)
+    @ccall libzmq.zmq_msg_init_size(msg_::Ptr{zmq_msg_t}, size_::Csize_t)::Cint
+end
+
+function zmq_msg_init_data(msg_, data_, size_, ffn_, hint_)
+    @ccall libzmq.zmq_msg_init_data(msg_::Ptr{zmq_msg_t}, data_::Ptr{Cvoid}, size_::Csize_t, ffn_::Ptr{zmq_free_fn}, hint_::Ptr{Cvoid})::Cint
+end
+
+function zmq_msg_send(msg_, s_, flags_)
+    @ccall libzmq.zmq_msg_send(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+end
+
+function zmq_msg_recv(msg_, s_, flags_)
+    @ccall libzmq.zmq_msg_recv(msg_::Ptr{zmq_msg_t}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+end
+
+function zmq_msg_close(msg_)
+    @ccall libzmq.zmq_msg_close(msg_::Ptr{zmq_msg_t})::Cint
+end
+
+function zmq_msg_move(dest_, src_)
+    @ccall libzmq.zmq_msg_move(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
+end
+
+function zmq_msg_copy(dest_, src_)
+    @ccall libzmq.zmq_msg_copy(dest_::Ptr{zmq_msg_t}, src_::Ptr{zmq_msg_t})::Cint
+end
+
+function zmq_msg_data(msg_)
+    @ccall libzmq.zmq_msg_data(msg_::Ptr{zmq_msg_t})::Ptr{Cvoid}
+end
+
+function zmq_msg_size(msg_)
+    @ccall libzmq.zmq_msg_size(msg_::Ptr{zmq_msg_t})::Csize_t
+end
+
+function zmq_msg_more(msg_)
+    @ccall libzmq.zmq_msg_more(msg_::Ptr{zmq_msg_t})::Cint
+end
+
+function zmq_msg_get(msg_, property_)
+    @ccall libzmq.zmq_msg_get(msg_::Ptr{zmq_msg_t}, property_::Cint)::Cint
+end
+
+function zmq_msg_set(msg_, property_, optval_)
+    @ccall libzmq.zmq_msg_set(msg_::Ptr{zmq_msg_t}, property_::Cint, optval_::Cint)::Cint
+end
+
+function zmq_msg_gets(msg_, property_)
+    @ccall libzmq.zmq_msg_gets(msg_::Ptr{zmq_msg_t}, property_::Ptr{Cchar})::Ptr{Cchar}
+end
+
+function zmq_socket(arg1, type_)
+    @ccall libzmq.zmq_socket(arg1::Ptr{Cvoid}, type_::Cint)::Ptr{Cvoid}
+end
+
+function zmq_close(s_)
+    @ccall libzmq.zmq_close(s_::Ptr{Cvoid})::Cint
+end
+
+function zmq_setsockopt(s_, option_, optval_, optvallen_)
+    @ccall libzmq.zmq_setsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Csize_t)::Cint
+end
+
+function zmq_getsockopt(s_, option_, optval_, optvallen_)
+    @ccall libzmq.zmq_getsockopt(s_::Ptr{Cvoid}, option_::Cint, optval_::Ptr{Cvoid}, optvallen_::Ptr{Csize_t})::Cint
+end
+
+function zmq_bind(s_, addr_)
+    @ccall libzmq.zmq_bind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+end
+
+function zmq_connect(s_, addr_)
+    @ccall libzmq.zmq_connect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+end
+
+function zmq_unbind(s_, addr_)
+    @ccall libzmq.zmq_unbind(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+end
+
+function zmq_disconnect(s_, addr_)
+    @ccall libzmq.zmq_disconnect(s_::Ptr{Cvoid}, addr_::Ptr{Cchar})::Cint
+end
+
+function zmq_send(s_, buf_, len_, flags_)
+    @ccall libzmq.zmq_send(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+end
+
+function zmq_send_const(s_, buf_, len_, flags_)
+    @ccall libzmq.zmq_send_const(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+end
+
+function zmq_recv(s_, buf_, len_, flags_)
+    @ccall libzmq.zmq_recv(s_::Ptr{Cvoid}, buf_::Ptr{Cvoid}, len_::Csize_t, flags_::Cint)::Cint
+end
+
+function zmq_socket_monitor(s_, addr_, events_)
+    @ccall libzmq.zmq_socket_monitor(s_::Ptr{Cvoid}, addr_::Ptr{Cchar}, events_::Cint)::Cint
+end
+
+const zmq_fd_t = Cint
+
+mutable struct zmq_pollitem_t
+    socket::Ptr{Cvoid}
+    fd::zmq_fd_t
+    events::Cshort
+    revents::Cshort
+end
+
+function zmq_poll(items_, nitems_, timeout_)
+    @ccall libzmq.zmq_poll(items_::Ptr{zmq_pollitem_t}, nitems_::Cint, timeout_::Clong)::Cint
+end
+
+function zmq_proxy(frontend_, backend_, capture_)
+    @ccall libzmq.zmq_proxy(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid})::Cint
+end
+
+function zmq_proxy_steerable(frontend_, backend_, capture_, control_)
+    @ccall libzmq.zmq_proxy_steerable(frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid}, capture_::Ptr{Cvoid}, control_::Ptr{Cvoid})::Cint
+end
+
+function zmq_has(capability_)
+    @ccall libzmq.zmq_has(capability_::Ptr{Cchar})::Cint
+end
+
+function zmq_device(type_, frontend_, backend_)
+    @ccall libzmq.zmq_device(type_::Cint, frontend_::Ptr{Cvoid}, backend_::Ptr{Cvoid})::Cint
+end
+
+function zmq_sendmsg(s_, msg_, flags_)
+    @ccall libzmq.zmq_sendmsg(s_::Ptr{Cvoid}, msg_::Ptr{zmq_msg_t}, flags_::Cint)::Cint
+end
+
+function zmq_recvmsg(s_, msg_, flags_)
+    @ccall libzmq.zmq_recvmsg(s_::Ptr{Cvoid}, msg_::Ptr{zmq_msg_t}, flags_::Cint)::Cint
+end
+
+mutable struct iovec end
+
+function zmq_sendiov(s_, iov_, count_, flags_)
+    @ccall libzmq.zmq_sendiov(s_::Ptr{Cvoid}, iov_::Ptr{iovec}, count_::Csize_t, flags_::Cint)::Cint
+end
+
+function zmq_recviov(s_, iov_, count_, flags_)
+    @ccall libzmq.zmq_recviov(s_::Ptr{Cvoid}, iov_::Ptr{iovec}, count_::Ptr{Csize_t}, flags_::Cint)::Cint
+end
+
+function zmq_z85_encode(dest_, data_, size_)
+    @ccall libzmq.zmq_z85_encode(dest_::Ptr{Cchar}, data_::Ptr{UInt8}, size_::Csize_t)::Ptr{Cchar}
+end
+
+function zmq_z85_decode(dest_, string_)
+    @ccall libzmq.zmq_z85_decode(dest_::Ptr{UInt8}, string_::Ptr{Cchar})::Ptr{UInt8}
+end
+
+function zmq_curve_keypair(z85_public_key_, z85_secret_key_)
+    @ccall libzmq.zmq_curve_keypair(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
+end
+
+function zmq_curve_public(z85_public_key_, z85_secret_key_)
+    @ccall libzmq.zmq_curve_public(z85_public_key_::Ptr{Cchar}, z85_secret_key_::Ptr{Cchar})::Cint
+end
+
+function zmq_atomic_counter_new()
+    @ccall libzmq.zmq_atomic_counter_new()::Ptr{Cvoid}
+end
+
+function zmq_atomic_counter_set(counter_, value_)
+    @ccall libzmq.zmq_atomic_counter_set(counter_::Ptr{Cvoid}, value_::Cint)::Cvoid
+end
+
+function zmq_atomic_counter_inc(counter_)
+    @ccall libzmq.zmq_atomic_counter_inc(counter_::Ptr{Cvoid})::Cint
+end
+
+function zmq_atomic_counter_dec(counter_)
+    @ccall libzmq.zmq_atomic_counter_dec(counter_::Ptr{Cvoid})::Cint
+end
+
+function zmq_atomic_counter_value(counter_)
+    @ccall libzmq.zmq_atomic_counter_value(counter_::Ptr{Cvoid})::Cint
+end
+
+function zmq_atomic_counter_destroy(counter_p_)
+    @ccall libzmq.zmq_atomic_counter_destroy(counter_p_::Ptr{Ptr{Cvoid}})::Cvoid
+end
+
+# typedef void ( zmq_timer_fn ) ( int timer_id , void * arg )
+const zmq_timer_fn = Cvoid
+
+function zmq_timers_new()
+    @ccall libzmq.zmq_timers_new()::Ptr{Cvoid}
+end
+
+function zmq_timers_destroy(timers_p)
+    @ccall libzmq.zmq_timers_destroy(timers_p::Ptr{Ptr{Cvoid}})::Cint
+end
+
+function zmq_timers_add(timers, interval, handler, arg)
+    @ccall libzmq.zmq_timers_add(timers::Ptr{Cvoid}, interval::Csize_t, handler::zmq_timer_fn, arg::Ptr{Cvoid})::Cint
+end
+
+function zmq_timers_cancel(timers, timer_id)
+    @ccall libzmq.zmq_timers_cancel(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
+end
+
+function zmq_timers_set_interval(timers, timer_id, interval)
+    @ccall libzmq.zmq_timers_set_interval(timers::Ptr{Cvoid}, timer_id::Cint, interval::Csize_t)::Cint
+end
+
+function zmq_timers_reset(timers, timer_id)
+    @ccall libzmq.zmq_timers_reset(timers::Ptr{Cvoid}, timer_id::Cint)::Cint
+end
+
+function zmq_timers_timeout(timers)
+    @ccall libzmq.zmq_timers_timeout(timers::Ptr{Cvoid})::Clong
+end
+
+function zmq_timers_execute(timers)
+    @ccall libzmq.zmq_timers_execute(timers::Ptr{Cvoid})::Cint
+end
+
+function zmq_stopwatch_start()
+    @ccall libzmq.zmq_stopwatch_start()::Ptr{Cvoid}
+end
+
+function zmq_stopwatch_intermediate(watch_)
+    @ccall libzmq.zmq_stopwatch_intermediate(watch_::Ptr{Cvoid})::Culong
+end
+
+function zmq_stopwatch_stop(watch_)
+    @ccall libzmq.zmq_stopwatch_stop(watch_::Ptr{Cvoid})::Culong
+end
+
+function zmq_sleep(seconds_)
+    @ccall libzmq.zmq_sleep(seconds_::Cint)::Cvoid
+end
+
+# typedef void ( zmq_thread_fn ) ( void * )
+const zmq_thread_fn = Cvoid
+
+function zmq_threadstart(func_, arg_)
+    @ccall libzmq.zmq_threadstart(func_::Ptr{zmq_thread_fn}, arg_::Ptr{Cvoid})::Ptr{Cvoid}
+end
+
+function zmq_threadclose(thread_)
+    @ccall libzmq.zmq_threadclose(thread_::Ptr{Cvoid})::Cvoid
+end
+
+const ZMQ_VERSION_MAJOR = 4
+
+const ZMQ_VERSION_MINOR = 3
+
+const ZMQ_VERSION_PATCH = 5
+
+# Skipping MacroDefinition: ZMQ_EXPORT __attribute__ ( ( visibility ( "default" ) ) )
+
+const ZMQ_DEFINED_STDINT = 1
+
+const ZMQ_HAUSNUMERO = 156384712
+
+const EFSM = ZMQ_HAUSNUMERO + 51
+
+const ENOCOMPATPROTO = ZMQ_HAUSNUMERO + 52
+
+const ETERM = ZMQ_HAUSNUMERO + 53
+
+const EMTHREAD = ZMQ_HAUSNUMERO + 54
+
+const ZMQ_IO_THREADS = 1
+
+const ZMQ_MAX_SOCKETS = 2
+
+const ZMQ_SOCKET_LIMIT = 3
+
+const ZMQ_THREAD_PRIORITY = 3
+
+const ZMQ_THREAD_SCHED_POLICY = 4
+
+const ZMQ_MAX_MSGSZ = 5
+
+const ZMQ_MSG_T_SIZE = 6
+
+const ZMQ_THREAD_AFFINITY_CPU_ADD = 7
+
+const ZMQ_THREAD_AFFINITY_CPU_REMOVE = 8
+
+const ZMQ_THREAD_NAME_PREFIX = 9
+
+const ZMQ_IO_THREADS_DFLT = 1
+
+const ZMQ_MAX_SOCKETS_DFLT = 1023
+
+const ZMQ_THREAD_PRIORITY_DFLT = -1
+
+const ZMQ_THREAD_SCHED_POLICY_DFLT = -1
+
+const ZMQ_PAIR = 0
+
+const ZMQ_PUB = 1
+
+const ZMQ_SUB = 2
+
+const ZMQ_REQ = 3
+
+const ZMQ_REP = 4
+
+const ZMQ_DEALER = 5
+
+const ZMQ_ROUTER = 6
+
+const ZMQ_PULL = 7
+
+const ZMQ_PUSH = 8
+
+const ZMQ_XPUB = 9
+
+const ZMQ_XSUB = 10
+
+const ZMQ_STREAM = 11
+
+const ZMQ_XREQ = ZMQ_DEALER
+
+const ZMQ_XREP = ZMQ_ROUTER
+
+const ZMQ_AFFINITY = 4
+
+const ZMQ_ROUTING_ID = 5
+
+const ZMQ_SUBSCRIBE = 6
+
+const ZMQ_UNSUBSCRIBE = 7
+
+const ZMQ_RATE = 8
+
+const ZMQ_RECOVERY_IVL = 9
+
+const ZMQ_SNDBUF = 11
+
+const ZMQ_RCVBUF = 12
+
+const ZMQ_RCVMORE = 13
+
+const ZMQ_FD = 14
+
+const ZMQ_EVENTS = 15
+
+const ZMQ_TYPE = 16
+
+const ZMQ_LINGER = 17
+
+const ZMQ_RECONNECT_IVL = 18
+
+const ZMQ_BACKLOG = 19
+
+const ZMQ_RECONNECT_IVL_MAX = 21
+
+const ZMQ_MAXMSGSIZE = 22
+
+const ZMQ_SNDHWM = 23
+
+const ZMQ_RCVHWM = 24
+
+const ZMQ_MULTICAST_HOPS = 25
+
+const ZMQ_RCVTIMEO = 27
+
+const ZMQ_SNDTIMEO = 28
+
+const ZMQ_LAST_ENDPOINT = 32
+
+const ZMQ_ROUTER_MANDATORY = 33
+
+const ZMQ_TCP_KEEPALIVE = 34
+
+const ZMQ_TCP_KEEPALIVE_CNT = 35
+
+const ZMQ_TCP_KEEPALIVE_IDLE = 36
+
+const ZMQ_TCP_KEEPALIVE_INTVL = 37
+
+const ZMQ_IMMEDIATE = 39
+
+const ZMQ_XPUB_VERBOSE = 40
+
+const ZMQ_ROUTER_RAW = 41
+
+const ZMQ_IPV6 = 42
+
+const ZMQ_MECHANISM = 43
+
+const ZMQ_PLAIN_SERVER = 44
+
+const ZMQ_PLAIN_USERNAME = 45
+
+const ZMQ_PLAIN_PASSWORD = 46
+
+const ZMQ_CURVE_SERVER = 47
+
+const ZMQ_CURVE_PUBLICKEY = 48
+
+const ZMQ_CURVE_SECRETKEY = 49
+
+const ZMQ_CURVE_SERVERKEY = 50
+
+const ZMQ_PROBE_ROUTER = 51
+
+const ZMQ_REQ_CORRELATE = 52
+
+const ZMQ_REQ_RELAXED = 53
+
+const ZMQ_CONFLATE = 54
+
+const ZMQ_ZAP_DOMAIN = 55
+
+const ZMQ_ROUTER_HANDOVER = 56
+
+const ZMQ_TOS = 57
+
+const ZMQ_CONNECT_ROUTING_ID = 61
+
+const ZMQ_GSSAPI_SERVER = 62
+
+const ZMQ_GSSAPI_PRINCIPAL = 63
+
+const ZMQ_GSSAPI_SERVICE_PRINCIPAL = 64
+
+const ZMQ_GSSAPI_PLAINTEXT = 65
+
+const ZMQ_HANDSHAKE_IVL = 66
+
+const ZMQ_SOCKS_PROXY = 68
+
+const ZMQ_XPUB_NODROP = 69
+
+const ZMQ_BLOCKY = 70
+
+const ZMQ_XPUB_MANUAL = 71
+
+const ZMQ_XPUB_WELCOME_MSG = 72
+
+const ZMQ_STREAM_NOTIFY = 73
+
+const ZMQ_INVERT_MATCHING = 74
+
+const ZMQ_HEARTBEAT_IVL = 75
+
+const ZMQ_HEARTBEAT_TTL = 76
+
+const ZMQ_HEARTBEAT_TIMEOUT = 77
+
+const ZMQ_XPUB_VERBOSER = 78
+
+const ZMQ_CONNECT_TIMEOUT = 79
+
+const ZMQ_TCP_MAXRT = 80
+
+const ZMQ_THREAD_SAFE = 81
+
+const ZMQ_MULTICAST_MAXTPDU = 84
+
+const ZMQ_VMCI_BUFFER_SIZE = 85
+
+const ZMQ_VMCI_BUFFER_MIN_SIZE = 86
+
+const ZMQ_VMCI_BUFFER_MAX_SIZE = 87
+
+const ZMQ_VMCI_CONNECT_TIMEOUT = 88
+
+const ZMQ_USE_FD = 89
+
+const ZMQ_GSSAPI_PRINCIPAL_NAMETYPE = 90
+
+const ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE = 91
+
+const ZMQ_BINDTODEVICE = 92
+
+const ZMQ_MORE = 1
+
+const ZMQ_SHARED = 3
+
+const ZMQ_DONTWAIT = 1
+
+const ZMQ_SNDMORE = 2
+
+const ZMQ_NULL = 0
+
+const ZMQ_PLAIN = 1
+
+const ZMQ_CURVE = 2
+
+const ZMQ_GSSAPI = 3
+
+const ZMQ_GROUP_MAX_LENGTH = 255
+
+const ZMQ_IDENTITY = ZMQ_ROUTING_ID
+
+const ZMQ_CONNECT_RID = ZMQ_CONNECT_ROUTING_ID
+
+const ZMQ_TCP_ACCEPT_FILTER = 38
+
+const ZMQ_IPC_FILTER_PID = 58
+
+const ZMQ_IPC_FILTER_UID = 59
+
+const ZMQ_IPC_FILTER_GID = 60
+
+const ZMQ_IPV4ONLY = 31
+
+const ZMQ_DELAY_ATTACH_ON_CONNECT = ZMQ_IMMEDIATE
+
+const ZMQ_NOBLOCK = ZMQ_DONTWAIT
+
+const ZMQ_FAIL_UNROUTABLE = ZMQ_ROUTER_MANDATORY
+
+const ZMQ_ROUTER_BEHAVIOR = ZMQ_ROUTER_MANDATORY
+
+const ZMQ_SRCFD = 2
+
+const ZMQ_GSSAPI_NT_HOSTBASED = 0
+
+const ZMQ_GSSAPI_NT_USER_NAME = 1
+
+const ZMQ_GSSAPI_NT_KRB5_PRINCIPAL = 2
+
+const ZMQ_EVENT_CONNECTED = 0x0001
+
+const ZMQ_EVENT_CONNECT_DELAYED = 0x0002
+
+const ZMQ_EVENT_CONNECT_RETRIED = 0x0004
+
+const ZMQ_EVENT_LISTENING = 0x0008
+
+const ZMQ_EVENT_BIND_FAILED = 0x0010
+
+const ZMQ_EVENT_ACCEPTED = 0x0020
+
+const ZMQ_EVENT_ACCEPT_FAILED = 0x0040
+
+const ZMQ_EVENT_CLOSED = 0x0080
+
+const ZMQ_EVENT_CLOSE_FAILED = 0x0100
+
+const ZMQ_EVENT_DISCONNECTED = 0x0200
+
+const ZMQ_EVENT_MONITOR_STOPPED = 0x0400
+
+const ZMQ_EVENT_ALL = 0xffff
+
+const ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL = 0x0800
+
+const ZMQ_EVENT_HANDSHAKE_SUCCEEDED = 0x1000
+
+const ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL = 0x2000
+
+const ZMQ_EVENT_HANDSHAKE_FAILED_AUTH = 0x4000
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED = 0x10000000
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND = 0x10000001
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE = 0x10000002
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE = 0x10000003
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED = 0x10000011
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE = 0x10000012
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO = 0x10000013
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE = 0x10000014
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR = 0x10000015
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY = 0x10000016
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME = 0x10000017
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA = 0x10000018
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC = 0x11000001
+
+const ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH = 0x11000002
+
+const ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED = 0x20000000
+
+const ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY = 0x20000001
+
+const ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID = 0x20000002
+
+const ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION = 0x20000003
+
+const ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE = 0x20000004
+
+const ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA = 0x20000005
+
+const ZMQ_PROTOCOL_ERROR_WS_UNSPECIFIED = 0x30000000
+
+const ZMQ_POLLIN = 1
+
+const ZMQ_POLLOUT = 2
+
+const ZMQ_POLLERR = 4
+
+const ZMQ_POLLPRI = 8
+
+const ZMQ_POLLITEMS_DFLT = 16
+
+const ZMQ_HAS_CAPABILITIES = 1
+
+const ZMQ_STREAMER = 1
+
+const ZMQ_FORWARDER = 2
+
+const ZMQ_QUEUE = 3
+
+end # module

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -3,15 +3,10 @@
 
 ############################################################################
 
-msg_send(socket::Socket, zmsg::_MessageOrRef, flags::Integer) =
-    ccall((:zmq_msg_send, libzmq), Cint, (Ref{_Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
-msg_send(socket::Socket, zmsg::Message, flags::Integer) =
-    ccall((:zmq_msg_send, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
-
 function _send(socket::Socket, zmsg, more::Bool=false)
     while true
-        if -1 == msg_send(socket, zmsg, (ZMQ_SNDMORE*more) | ZMQ_DONTWAIT)
-            zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
+        if -1 == lib.zmq_msg_send(zmsg, socket, (ZMQ_SNDMORE*more) | ZMQ_DONTWAIT)
+            lib.zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
             while (socket.events & POLLOUT) == 0
                 wait(socket)
             end
@@ -67,15 +62,10 @@ end
 
 ############################################################################
 
-msg_recv(socket::Socket, zmsg::_MessageOrRef, flags::Integer) =
-    ccall((:zmq_msg_recv, libzmq), Cint, (Ref{_Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
-msg_recv(socket::Socket, zmsg::Message, flags::Integer) =
-    ccall((:zmq_msg_recv, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), zmsg, socket, flags)
-
 function _recv!(socket::Socket, zmsg)
     while true
-        if -1 == msg_recv(socket, zmsg, ZMQ_DONTWAIT)
-            zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
+        if -1 == lib.zmq_msg_recv(zmsg, socket, ZMQ_DONTWAIT)
+            lib.zmq_errno() == EAGAIN || throw(StateError(jl_zmq_error_str()))
             while socket.events & POLLIN== 0
                 wait(socket)
             end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -2,32 +2,32 @@
 ## Constants
 
 # Context options
-const IO_THREADS = 1
-const MAX_SOCKETS = 2
-const IPV6 = 42
+const IO_THREADS = lib.ZMQ_IO_THREADS
+const MAX_SOCKETS = lib.ZMQ_MAX_SOCKETS
+const IPV6 = lib.ZMQ_IPV6
 
 "[PAIR](https://zeromq.org/socket-api/#pair-socket) socket."
-const PAIR = 0
+const PAIR = lib.ZMQ_PAIR
 "[PUB](https://zeromq.org/socket-api/#pub-socket) socket."
-const PUB = 1
+const PUB = lib.ZMQ_PUB
 "[SUB](https://zeromq.org/socket-api/#sub-socket) socket."
-const SUB = 2
+const SUB = lib.ZMQ_SUB
 "[REQ](https://zeromq.org/socket-api/#req-socket) socket."
-const REQ = 3
+const REQ = lib.ZMQ_REQ
 "[REP](https://zeromq.org/socket-api/#rep-socket) socket."
-const REP = 4
+const REP = lib.ZMQ_REP
 "[DEALER](https://zeromq.org/socket-api/#dealer-socket) socket."
-const DEALER = 5
+const DEALER = lib.ZMQ_DEALER
 "[ROUTER](https://zeromq.org/socket-api/#router-socket) socket."
-const ROUTER = 6
+const ROUTER = lib.ZMQ_ROUTER
 "[PULL](https://zeromq.org/socket-api/#pull-socket) socket."
-const PULL = 7
+const PULL = lib.ZMQ_PULL
 "[PUSH](https://zeromq.org/socket-api/#push-socket) socket."
-const PUSH = 8
+const PUSH = lib.ZMQ_PUSH
 "[XPUB](https://zeromq.org/socket-api/#xpub-socket) socket."
-const XPUB = 9
+const XPUB = lib.ZMQ_XPUB
 "[XSUB](https://zeromq.org/socket-api/#xsub-socket) socket."
-const XSUB = 10
+const XSUB = lib.ZMQ_XSUB
 """
 [XREQ](https://zeromq.org/socket-api/#dealer-socket) socket.
 
@@ -61,20 +61,20 @@ const UPSTREAM = PULL
 const DOWNSTREAM = PUSH
 
 #Message options
-const MORE = 1
+const MORE = lib.ZMQ_MORE
 const SNDMORE = true
 
 #IO Multiplexing
-const POLLIN = 1
-const POLLOUT = 2
-const POLLERR = 4
+const POLLIN = lib.ZMQ_POLLIN
+const POLLOUT = lib.ZMQ_POLLOUT
+const POLLERR = lib.ZMQ_POLLERR
 
 #Built in devices
-const STREAMER = 1
-const FORWARDER = 2
-const QUEUE = 3
+const STREAMER = lib.ZMQ_STREAMER
+const FORWARDER = lib.ZMQ_FORWARDER
+const QUEUE = lib.ZMQ_QUEUE
 
 
 #Send/Recv Options
-const ZMQ_DONTWAIT = 1
-const ZMQ_SNDMORE = 2
+const ZMQ_DONTWAIT = lib.ZMQ_DONTWAIT
+const ZMQ_SNDMORE = lib.ZMQ_SNDMORE

--- a/src/context.jl
+++ b/src/context.jl
@@ -14,7 +14,7 @@ mutable struct Context
     data::Ptr{Cvoid}
 
     # need to keep a list of weakrefs to sockets for this Context in order to
-    # close them before finalizing (otherwise zmq_term will hang)
+    # close them before finalizing (otherwise zmq_ctx_term will hang)
     sockets::Vector{WeakRef}
 
     function Context()
@@ -73,7 +73,7 @@ function Base.close(ctx::Context)
             end
         end
         empty!(getfield(ctx, :sockets))
-        rc = lib.zmq_ctx_destroy(ctx)
+        rc = lib.zmq_ctx_term(ctx)
         setfield!(ctx, :data, C_NULL)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))

--- a/src/context.jl
+++ b/src/context.jl
@@ -3,7 +3,7 @@
 
 # the low-level context constructor
 function _ctx_new()
-    p = ccall((:zmq_ctx_new, libzmq), Ptr{Cvoid},  ())
+    p = lib.zmq_ctx_new()
     if p == C_NULL
         throw(StateError(jl_zmq_error_str()))
     end
@@ -73,7 +73,7 @@ function Base.close(ctx::Context)
             end
         end
         empty!(getfield(ctx, :sockets))
-        rc = ccall((:zmq_ctx_destroy, libzmq), Cint,  (Ptr{Cvoid},), ctx)
+        rc = lib.zmq_ctx_destroy(ctx)
         setfield!(ctx, :data, C_NULL)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
@@ -83,14 +83,14 @@ end
 @deprecate term(ctx::Context) close(ctx)
 
 function _get(ctx::Context, option::Integer)
-    val = ccall((:zmq_ctx_get, libzmq), Cint, (Ptr{Cvoid}, Cint), ctx, option)
+    val = lib.zmq_ctx_get(ctx, option)
     if val < 0
         throw(StateError(jl_zmq_error_str()))
     end
     return val
 end
 function _set(ctx::Context, option::Integer, value::Integer)
-    rc = ccall((:zmq_ctx_set, libzmq), Cint, (Ptr{Cvoid}, Cint, Cint), ctx, option, value)
+    rc = lib.zmq_ctx_set(ctx, option, value)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end

--- a/src/error.jl
+++ b/src/error.jl
@@ -8,10 +8,11 @@ end
 show(io, thiserr::StateError) = print(io, "ZMQ: ", thiserr.msg)
 
 # Basic functions
-zmq_errno() = ccall((:zmq_errno, libzmq), Cint, ())
+
 function jl_zmq_error_str()
-    errno = zmq_errno()
-    c_strerror = ccall((:zmq_strerror, libzmq), Ptr{UInt8}, (Cint,), errno)
+    errno = lib.zmq_errno()
+    c_strerror = lib.zmq_strerror(errno)
+
     if c_strerror != C_NULL
         strerror = unsafe_string(c_strerror)
         return strerror

--- a/src/msg_bindings.jl
+++ b/src/msg_bindings.jl
@@ -2,58 +2,58 @@ import ZeroMQ_jll: libzmq
 import .lib: zmq_free_fn
 
 function lib.zmq_msg_init(msg_::Message)
-    @ccall libzmq.zmq_msg_init(msg_::Ref{Message})::Cint
+    ccall((:zmq_msg_init, libzmq), Cint, (Ref{Message},), msg_)
 end
 
 function lib.zmq_msg_init_size(msg_::Message, size_)
-    @ccall libzmq.zmq_msg_init_size(msg_::Ref{Message}, size_::Csize_t)::Cint
+    ccall((:zmq_msg_init_size, libzmq), Cint, (Ref{Message}, Csize_t), msg_, size_)
 end
 
 function lib.zmq_msg_init_data(msg_::Message, data_, size_, ffn_, hint_)
-    @ccall libzmq.zmq_msg_init_data(msg_::Ref{Message}, data_::Ptr{Cvoid}, size_::Csize_t, ffn_::Ptr{zmq_free_fn}, hint_::Ptr{Cvoid})::Cint
+    ccall((:zmq_msg_init_data, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Csize_t, Ptr{zmq_free_fn}, Ptr{Cvoid}), msg_, data_, size_, ffn_, hint_)
 end
 
 function lib.zmq_msg_send(msg_::Message, s_, flags_)
-    @ccall libzmq.zmq_msg_send(msg_::Ref{Message}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+    ccall((:zmq_msg_send, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), msg_, s_, flags_)
 end
 
 function lib.zmq_msg_recv(msg_::Message, s_, flags_)
-    @ccall libzmq.zmq_msg_recv(msg_::Ref{Message}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+    ccall((:zmq_msg_recv, libzmq), Cint, (Ref{Message}, Ptr{Cvoid}, Cint), msg_, s_, flags_)
 end
 
 function lib.zmq_msg_close(msg_::Message)
-    @ccall libzmq.zmq_msg_close(msg_::Ref{Message})::Cint
+    ccall((:zmq_msg_close, libzmq), Cint, (Ref{Message},), msg_)
 end
 
 function lib.zmq_msg_move(dest_::Message, src_)
-    @ccall libzmq.zmq_msg_move(dest_::Ref{Message}, src_::Ref{Message})::Cint
+    ccall((:zmq_msg_move, libzmq), Cint, (Ref{Message}, Ref{Message}), dest_, src_)
 end
 
 function lib.zmq_msg_copy(dest_::Message, src_)
-    @ccall libzmq.zmq_msg_copy(dest_::Ref{Message}, src_::Ref{Message})::Cint
+    ccall((:zmq_msg_copy, libzmq), Cint, (Ref{Message}, Ref{Message}), dest_, src_)
 end
 
 function lib.zmq_msg_data(msg_::Message)
-    @ccall libzmq.zmq_msg_data(msg_::Ref{Message})::Ptr{Cvoid}
+    ccall((:zmq_msg_data, libzmq), Ptr{Cvoid}, (Ref{Message},), msg_)
 end
 
 function lib.zmq_msg_size(msg_::Message)
-    @ccall libzmq.zmq_msg_size(msg_::Ref{Message})::Csize_t
+    ccall((:zmq_msg_size, libzmq), Csize_t, (Ref{Message},), msg_)
 end
 
 function lib.zmq_msg_more(msg_::Message)
-    @ccall libzmq.zmq_msg_more(msg_::Ref{Message})::Cint
+    ccall((:zmq_msg_more, libzmq), Cint, (Ref{Message},), msg_)
 end
 
 function lib.zmq_msg_get(msg_::Message, property_)
-    @ccall libzmq.zmq_msg_get(msg_::Ref{Message}, property_::Cint)::Cint
+    ccall((:zmq_msg_get, libzmq), Cint, (Ref{Message}, Cint), msg_, property_)
 end
 
 function lib.zmq_msg_set(msg_::Message, property_, optval_)
-    @ccall libzmq.zmq_msg_set(msg_::Ref{Message}, property_::Cint, optval_::Cint)::Cint
+    ccall((:zmq_msg_set, libzmq), Cint, (Ref{Message}, Cint, Cint), msg_, property_, optval_)
 end
 
 function lib.zmq_msg_gets(msg_::Message, property_)
-    @ccall libzmq.zmq_msg_gets(msg_::Ref{Message}, property_::Ptr{Cchar})::Ptr{Cchar}
+    ccall((:zmq_msg_gets, libzmq), Ptr{Cchar}, (Ref{Message}, Ptr{Cchar}), msg_, property_)
 end
 

--- a/src/msg_bindings.jl
+++ b/src/msg_bindings.jl
@@ -1,0 +1,59 @@
+import ZeroMQ_jll: libzmq
+import .lib: zmq_free_fn
+
+function lib.zmq_msg_init(msg_::Message)
+    @ccall libzmq.zmq_msg_init(msg_::Ref{Message})::Cint
+end
+
+function lib.zmq_msg_init_size(msg_::Message, size_)
+    @ccall libzmq.zmq_msg_init_size(msg_::Ref{Message}, size_::Csize_t)::Cint
+end
+
+function lib.zmq_msg_init_data(msg_::Message, data_, size_, ffn_, hint_)
+    @ccall libzmq.zmq_msg_init_data(msg_::Ref{Message}, data_::Ptr{Cvoid}, size_::Csize_t, ffn_::Ptr{zmq_free_fn}, hint_::Ptr{Cvoid})::Cint
+end
+
+function lib.zmq_msg_send(msg_::Message, s_, flags_)
+    @ccall libzmq.zmq_msg_send(msg_::Ref{Message}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+end
+
+function lib.zmq_msg_recv(msg_::Message, s_, flags_)
+    @ccall libzmq.zmq_msg_recv(msg_::Ref{Message}, s_::Ptr{Cvoid}, flags_::Cint)::Cint
+end
+
+function lib.zmq_msg_close(msg_::Message)
+    @ccall libzmq.zmq_msg_close(msg_::Ref{Message})::Cint
+end
+
+function lib.zmq_msg_move(dest_::Message, src_)
+    @ccall libzmq.zmq_msg_move(dest_::Ref{Message}, src_::Ref{Message})::Cint
+end
+
+function lib.zmq_msg_copy(dest_::Message, src_)
+    @ccall libzmq.zmq_msg_copy(dest_::Ref{Message}, src_::Ref{Message})::Cint
+end
+
+function lib.zmq_msg_data(msg_::Message)
+    @ccall libzmq.zmq_msg_data(msg_::Ref{Message})::Ptr{Cvoid}
+end
+
+function lib.zmq_msg_size(msg_::Message)
+    @ccall libzmq.zmq_msg_size(msg_::Ref{Message})::Csize_t
+end
+
+function lib.zmq_msg_more(msg_::Message)
+    @ccall libzmq.zmq_msg_more(msg_::Ref{Message})::Cint
+end
+
+function lib.zmq_msg_get(msg_::Message, property_)
+    @ccall libzmq.zmq_msg_get(msg_::Ref{Message}, property_::Cint)::Cint
+end
+
+function lib.zmq_msg_set(msg_::Message, property_, optval_)
+    @ccall libzmq.zmq_msg_set(msg_::Ref{Message}, property_::Cint, optval_::Cint)::Cint
+end
+
+function lib.zmq_msg_gets(msg_::Message, property_)
+    @ccall libzmq.zmq_msg_gets(msg_::Ref{Message}, property_::Ptr{Cchar})::Ptr{Cchar}
+end
+

--- a/src/socket.jl
+++ b/src/socket.jl
@@ -12,7 +12,7 @@ mutable struct Socket
     Create a socket in a given context.
     """
     function Socket(ctx::Context, typ::Integer)
-        p = ccall((:zmq_socket, libzmq), Ptr{Cvoid}, (Ptr{Cvoid}, Cint), ctx, typ)
+        p = lib.zmq_socket(ctx, typ)
         if p == C_NULL
             throw(StateError(jl_zmq_error_str()))
         end
@@ -58,7 +58,7 @@ Base.isopen(socket::Socket) = getfield(socket, :data) != C_NULL
 function Base.close(socket::Socket)
     if isopen(socket)
         close(getfield(socket, :pollfd))
-        rc = ccall((:zmq_close, libzmq), Cint,  (Ptr{Cvoid},), socket)
+        rc = lib.zmq_close(socket)
         setfield!(socket, :data, C_NULL)
         if rc != 0
             throw(StateError(jl_zmq_error_str()))
@@ -86,7 +86,7 @@ described
 [here](http://api.zeromq.org/4-3:zmq-bind). e.g. `tcp://127.0.0.1:42000`.
 """
 function Sockets.bind(socket::Socket, endpoint::AbstractString)
-    rc = ccall((:zmq_bind, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
+    rc = lib.zmq_bind(socket, endpoint)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end
@@ -98,7 +98,7 @@ end
 Connect the socket to an endpoint.
 """
 function Sockets.connect(socket::Socket, endpoint::AbstractString)
-    rc=ccall((:zmq_connect, libzmq), Cint, (Ptr{Cvoid}, Ptr{UInt8}), socket, endpoint)
+    rc = lib.zmq_connect(socket, endpoint)
     if rc != 0
         throw(StateError(jl_zmq_error_str()))
     end


### PR DESCRIPTION
This is a rather invasive change to use Clang.jl to generate bindings for everything in `zmq.h`, and then use those bindings in the rest of the library. My motivation for doing this is to make it easier to call the libzmq functions, both for us and for anyone who wants to use the low-level functions (e.g. for things we haven't explicitly wrapped). It's also nice to have the constants generated for us.

It touches a lot of internals so this would definitely benefit from a review from someone more familiar with them :sweat_smile: In particular the code for `_Message` and `Message`, which took me a while to understand. I've written down my understanding of how that works in the comments of `gen.jl`. For the reviewers: I've tried to keep the commits atomic, so it might be easiest to review the commits one-by-one. ~~I don't think it's quite ready to merge yet because I'd like to add some more docs, but it should be ready for review.~~

CC @stevengj, @vtjnash 