### PR TITLE
lookup localhost ip in precompile bind

### DIFF
--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -58,12 +58,14 @@ import PrecompileTools: @compile_workload
 
     s2=Socket(REQ)
 
-    ZMQ.bind(s1, "tcp://localhost:*")
+    # zmq < 4.3.5 can only bind to ip address or network interface, not hostname
+    localhost_ip = Sockets.getaddrinfo("localhost", Sockets.IPv4)
+    ZMQ.bind(s1, "tcp://$(localhost_ip):*")
     # Strip the trailing null-terminator
     last_endpoint = s1.last_endpoint[1:end - 1]
     # Parse the port from the endpoint
     port = parse(Int, split(last_endpoint, ":")[end])
-    ZMQ.connect(s2, "tcp://localhost:$(port)")
+    ZMQ.connect(s2, "tcp://$(localhost_ip):$(port)")
 
     msg = Message("test request")
 


### PR DESCRIPTION
not all versions of libzmq support binding to a hostname

this shouldn't change the assumption that lookup of localhost will work, since the bind to localhost that was there before relies on libzmq making the same getaddrinfo call

this fixes precompile of ZMQ.jl on Julia < 1.6

closes #236 