### PR TITLE
Add Julia 1.3 to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1.6'
+          - os: ubuntu-latest
+            arch: x64
+            version: '1.3'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Since this is the earliest version we officially support. Should prevent something like #236 from happening again.