### PR TITLE
Implement `lib_version()`

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,11 @@ CurrentModule = ZMQ
 This documents notable changes in ZMQ.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Added
+
+- [`lib_version()`](@ref) to get the libzmq version ([#240]).
 
 ## [v1.2.5] - 2024-05-28
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,4 +1,12 @@
+```@meta
+CurrentModule = ZMQ
+```
+
 # Reference
+
+```@docs
+lib_version
+```
 
 ## Sockets
 

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -29,13 +29,23 @@ include("sockopts.jl")
 include("message.jl")
 include("comm.jl")
 
-function __init__()
+"""
+    lib_version()
+
+Get the libzmq version number.
+"""
+function lib_version()
     major = Ref{Cint}()
     minor = Ref{Cint}()
     patch = Ref{Cint}()
     ccall((:zmq_version, libzmq), Cvoid, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), major, minor, patch)
-    global version = VersionNumber(major[], minor[], patch[])
-    if version < v"3"
+    return VersionNumber(major[], minor[], patch[])
+end
+
+const version = lib_version()
+
+function __init__()
+    if lib_version() < v"3"
         error("ZMQ version $version < 3 is not supported")
     end
     atexit() do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,6 +164,10 @@ end
     @test !isopen(leaked_ctx)
 end
 
+@testset "Utilities" begin
+    @test ZMQ.lib_version() isa VersionNumber
+end
+
 @testset "Aqua.jl" begin
     Aqua.test_all(ZMQ)
 end


### PR DESCRIPTION
This is a slightly nicer API than looking up the undocumented (and mutable) `ZMQ.version`, though `ZMQ.version` is left as a const global for backwards compatibility.