### PR TITLE
Close the default Context in the precompilation workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ZMQ"
 uuid = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
-version = "1.2.5"
+version = "1.2.6"
 
 [deps]
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -13,6 +13,11 @@ Changelog](https://keepachangelog.com).
 
 - [`lib_version()`](@ref) to get the libzmq version ([#240]).
 
+### Fixed
+
+- Fixed a precompilation bug that would cause creating a sysimage with
+  PackageCompiler.jl on Julia 1.6 to fail ([#242]).
+
 ## [v1.2.5] - 2024-05-28
 
 ### Fixed

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,7 +7,7 @@ CurrentModule = ZMQ
 This documents notable changes in ZMQ.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## Unreleased
+## [v1.2.6] - 2024-06-13
 
 ### Added
 

--- a/src/ZMQ.jl
+++ b/src/ZMQ.jl
@@ -85,6 +85,13 @@ import PrecompileTools: @compile_workload
     unsafe_string(ZMQ.recv(s2))
     ZMQ.close(s1)
     ZMQ.close(s2)
+
+    # Using the library like this workload will initialize ZMQ._context, which
+    # contains a pointer. This doesn't seem to play well with serialization on
+    # Julia 1.6 with PackageCompiler so we explicitly close it to reset the
+    # pointer.
+    # See: https://github.com/JuliaLang/julia/issues/46214
+    close(ZMQ._context)
 end
 
 end


### PR DESCRIPTION
Should fix #241.