### PR TITLE
Add moar tests and fix `isfreed()`

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -13,6 +13,10 @@ Changelog](https://keepachangelog.com).
 - Support for creating [`Message`](@ref)'s from the new `Memory` type in Julia
   1.11 ([#244]).
 
+### Fixed
+- Fixed [`isfreed()`](@ref), which would previously return the wrong values
+  ([#245]).
+
 ## [v1.2.6] - 2024-06-13
 
 ### Added

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -60,6 +60,7 @@ Message(::String)
 Message(::SubString{String})
 Message(::Array)
 Message(::IOBuffer)
+isfreed(::Message)
 ```
 
 ## Context

--- a/src/message.jl
+++ b/src/message.jl
@@ -129,9 +129,13 @@ mutable struct Message <: AbstractArray{UInt8,1}
     end
 end
 
-# check whether zeromq has called our free-function, i.e. whether
-# we are save to reclaim ownership of any buffer object
-isfreed(m::Message) = haskey(gc_protect, getfield(m, :handle))
+"""
+    isfreed(m::Message)
+
+Check whether zeromq has called our free-function, i.e. whether we are safe to
+reclaim ownership of any buffer object the [`Message`](@ref) was created with.
+"""
+isfreed(m::Message) = !haskey(gc_protect, getfield(m, :handle))
 
 # AbstractArray behaviors:
 Base.similar(a::Message, ::Type{T}, dims::Dims) where {T} = Array{T}(undef, dims) # ?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -170,7 +170,7 @@ end
     @test String(ZMQ.recv(s2)) == str_msg
 
     # Message(::SubString)
-    m4 = Message(@view str_msg[1:3])
+    m4 = Message(SubString(str_msg, 1:3))
     ZMQ.send(s1, m4)
     @test String(ZMQ.recv(s2)) == str_msg[1:3]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,8 +136,8 @@ end
     @test !isopen(s2)
 end
 
-# Test all the send constructors
 @testset "Message" begin
+    # Test all the send constructors
     s1 = Socket(PUB)
     s2 = Socket(SUB)
     ZMQ.subscribe(s2, "")
@@ -170,7 +170,7 @@ end
     @test String(ZMQ.recv(s2)) == str_msg
 
     # Message(::SubString)
-    m4 = Message(str_msg[1:3])
+    m4 = Message(@view str_msg[1:3])
     ZMQ.send(s1, m4)
     @test String(ZMQ.recv(s2)) == str_msg[1:3]
 
@@ -187,8 +187,21 @@ end
     ZMQ.send(s1, m6)
     @test ZMQ.recv(s2) == buffer3
 
+    close(iobuf)
+    @test_throws ErrorException Message(iobuf)
+
     close(s1)
     close(s2)
+
+    # Test indexing
+    m = Message(10)
+    @test_throws BoundsError m[0]
+    @test_throws BoundsError m[11]
+
+    # Smoke tests
+    @test !Bool(m.more)
+    @test_throws ErrorException m.more = true
+    @test ZMQ.isfreed(m)
 end
 
 @testset "ZMQ resource management" begin


### PR DESCRIPTION
I was going through our coverage and adding some tests for low hanging fruit, and I noticed that the definition of `isfreed()` might be wrong? I changed it in e5d75e9 to return whether the message handle is *not* in `gc_protect`; if I read the code correctly it will be held in the dict until ZMQ has finished with it and called `gc_free_fn()`, which will delete it from the dict.