### PR TITLE
Add the Message(::DenseVector) constructor back to the docs

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -58,7 +58,7 @@ Message(::Integer)
 Message(::Any)
 Message(::String)
 Message(::SubString{String})
-Message(::Array)
+Message(::DenseVector)
 Message(::IOBuffer)
 isfreed(::Message)
 ```

--- a/src/message.jl
+++ b/src/message.jl
@@ -129,8 +129,8 @@ mutable struct Message <: AbstractArray{UInt8, 1}
     Create a message with an array as a buffer (for send). Note: the same
     ownership semantics as for [`Message(m::String)`](@ref) apply.
 
-    Usually `a` will be a 1D `Array`/`Vector`, but on 1.11+ it can also be a
-    `Memory`.
+    Usually `a` will be a 1D `Array`/`Vector`, but on Julia 1.11+ it can also be
+    a `Memory`.
     """
     Message(a::T) where T <: DenseVector = Message(a, pointer(a), sizeof(a))
 


### PR DESCRIPTION
Previously `Message(::Array)` would match against the `Message(::Any, ::Ptr, ::Integer)` constructor (which was documented twice).