### PR TITLE
Use [sources] for the docs project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,7 @@ jobs:
         with:
           version: '1'
       - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+          julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
             using Documenter: doctest

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,6 @@
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
+
+[sources]
+ZMQ = { path = ".." }


### PR DESCRIPTION
Now we don't have to explicitly dev the package project, which is kinda nice.